### PR TITLE
feat(create): add max_piece_length flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ jobs:
     private: false
     # piece_length is automatically optimized based on file size:
     # piece_length: 22  # manual override if needed (2^n: 14-24)
+    # max_piece_length: 23  # limits the automatically calculated maximum piece length
 
   - output: release.torrent
     path: /path/to/release
@@ -159,6 +160,7 @@ presets:
       - "https://please.passthe.tea/announce"
     # piece_length is automatically optimized based on file size
     # piece_length: 20  # manual override if needed (2^n: 14-24)
+    # max_piece_length: 23  # limits the automatically calculated maximum piece length
 
   # Public tracker preset
   public:
@@ -169,6 +171,7 @@ presets:
       - "udp://9.rarbg.com:2810/announce"
     # piece_length is automatically optimized based on file size
     # piece_length: 22  # manual override if needed (2^n: 14-24)
+    # max_piece_length: 23  # limits the automatically calculated maximum piece length
 ```
 
 #### Create Flags
@@ -187,6 +190,7 @@ Single mode flags:
 - `-p, --private`: Make torrent private (default: true)
 - `-c, --comment <text>`: Add comment
 - `-l, --piece-length <n>`: Set piece length to 2^n bytes (14-24, automatic if not specified)
+- `-m, --max-piece-length <n>`: Limit maximum piece length to 2^n bytes (14-24, unlimited if not specified)
 - `-o, --output <path>`: Set output path (default: <name>.torrent)
 - `-s, --source <text>`: Add source string
 - `-d, --no-date`: Don't write creation date
@@ -202,17 +206,18 @@ The batch configuration file uses YAML format with the following structure:
 # yaml-language-server: $schema=https://raw.githubusercontent.com/autobrr/mkbrr/main/schema/batch.json
 version: 1  # Required, must be 1
 jobs:       # List of torrent creation jobs
-  - output: string      # Required: Output path for .torrent file
-    path: string        # Required: Path to source file/directory
-    trackers:           # Optional: List of tracker URLs
+  - output: string         # Required: Output path for .torrent file
+    path: string           # Required: Path to source file/directory
+    trackers:              # Optional: List of tracker URLs
       - string
-    webseeds:           # Optional: List of webseed URLs
+    webseeds:              # Optional: List of webseed URLs
       - string
-    private: bool       # Optional: Make torrent private (default: true)
-    piece_length: int   # Optional: Piece length exponent (14-24)
-    comment: string     # Optional: Torrent comment
-    source: string      # Optional: Source tag
-    no_date: bool       # Optional: Don't write creation date (default: false)
+    private: bool          # Optional: Make torrent private (default: true)
+    piece_length: int      # Optional: Piece length exponent (14-24)
+    max_piece_length: int  # Optional: Limits the automatically calculated maximum piece length
+    comment: string        # Optional: Torrent comment
+    source: string         # Optional: Source tag
+    no_date: bool          # Optional: Don't write creation date (default: false)
 ```
 
 #### Preset Configuration Format
@@ -233,15 +238,16 @@ default:
 
 presets:      # Map of preset names to their configurations
   preset-name:
-    trackers:           # Optional: List of tracker URLs (overrides default)
+    trackers:              # Optional: List of tracker URLs (overrides default)
       - string
-    webseeds:           # Optional: List of webseed URLs (overrides default)
+    webseeds:              # Optional: List of webseed URLs (overrides default)
       - string
-    private: bool       # Optional: Make torrent private (overrides default)
-    piece_length: int   # Optional: Piece length exponent (14-24)
-    comment: string     # Optional: Torrent comment (overrides default)
-    source: string      # Optional: Source tag (overrides default)
-    no_date: bool       # Optional: Don't write creation date (overrides default)
+    private: bool          # Optional: Make torrent private (overrides default)
+    piece_length: int      # Optional: Piece length exponent (14-24)
+    max_piece_length: int  # Optional: Limits the automatically calculated maximum piece length
+    comment: string        # Optional: Torrent comment (overrides default)
+    source: string         # Optional: Source tag (overrides default)
+    no_date: bool          # Optional: Don't write creation date (overrides default)
 ```
 
 Any settings specified in a preset will override the corresponding default settings. This allows you to set common values in the `default` section and only specify differences in individual presets.
@@ -264,6 +270,7 @@ presets:
       - "https://please.passthe.tea/announce"
     # piece_length is automatically optimized based on file size
     # piece_length: 20  # manual override if needed (2^n: 14-24)
+    # max_piece_length: 23  # limits the automatically calculated maximum piece length
 
   # Public tracker preset
   public:
@@ -274,6 +281,7 @@ presets:
       - "udp://9.rarbg.com:2810/announce"
     # piece_length is automatically optimized based on file size
     # piece_length: 22  # manual override if needed (2^n: 14-24)
+    # max_piece_length: 23  # limits the automatically calculated maximum piece length
 ```
 
 ### Inspect a Torrent

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -12,18 +12,19 @@ import (
 )
 
 var (
-	trackerURL     string
-	isPrivate      bool
-	comment        string
-	pieceLengthExp *uint // for 2^n piece length, nil means automatic
-	outputPath     string
-	webSeeds       []string
-	noDate         bool
-	source         string
-	verbose        bool
-	batchFile      string
-	presetName     string
-	presetFile     string
+	trackerURL        string
+	isPrivate         bool
+	comment           string
+	pieceLengthExp    *uint // for 2^n piece length, nil means automatic
+	maxPieceLengthExp *uint // for maximum 2^n piece length, nil means no limit
+	outputPath        string
+	webSeeds          []string
+	noDate            bool
+	source            string
+	verbose           bool
+	batchFile         string
+	presetName        string
+	presetFile        string
 )
 
 var createCmd = &cobra.Command{
@@ -68,11 +69,15 @@ func init() {
 
 	// piece length flag allows setting a fixed piece size of 2^n bytes
 	// if not specified, piece length is calculated automatically based on total size
-	var defaultPieceLength uint
+	var defaultPieceLength, defaultMaxPieceLength uint
 	createCmd.Flags().UintVarP(&defaultPieceLength, "piece-length", "l", 0, "set piece length to 2^n bytes (14-24, automatic if not specified)")
+	createCmd.Flags().UintVarP(&defaultMaxPieceLength, "max-piece-length", "m", 0, "set maximum piece length to 2^n bytes (14-24, unlimited if not specified)")
 	createCmd.PreRun = func(cmd *cobra.Command, args []string) {
 		if cmd.Flags().Changed("piece-length") {
 			pieceLengthExp = &defaultPieceLength
+		}
+		if cmd.Flags().Changed("max-piece-length") {
+			maxPieceLengthExp = &defaultMaxPieceLength
 		}
 	}
 
@@ -182,6 +187,9 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		if cmd.Flags().Changed("piece-length") {
 			opts.PieceLengthExp = pieceLengthExp
 		}
+		if cmd.Flags().Changed("max-piece-length") {
+			opts.MaxPieceLength = maxPieceLengthExp
+		}
 		if cmd.Flags().Changed("source") {
 			opts.Source = source
 		}
@@ -197,6 +205,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 			IsPrivate:      isPrivate,
 			Comment:        comment,
 			PieceLengthExp: pieceLengthExp,
+			MaxPieceLength: maxPieceLengthExp,
 			Source:         source,
 			NoDate:         noDate,
 			Verbose:        verbose,

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -71,7 +71,7 @@ func init() {
 	// if not specified, piece length is calculated automatically based on total size
 	var defaultPieceLength, defaultMaxPieceLength uint
 	createCmd.Flags().UintVarP(&defaultPieceLength, "piece-length", "l", 0, "set piece length to 2^n bytes (14-24, automatic if not specified)")
-	createCmd.Flags().UintVarP(&defaultMaxPieceLength, "max-piece-length", "m", 0, "set maximum piece length to 2^n bytes (14-24, unlimited if not specified)")
+	createCmd.Flags().UintVarP(&defaultMaxPieceLength, "max-piece-length", "m", 0, "limit maximum piece length to 2^n bytes (14-24, unlimited if not specified)")
 	createCmd.PreRun = func(cmd *cobra.Command, args []string) {
 		if cmd.Flags().Changed("piece-length") {
 			pieceLengthExp = &defaultPieceLength

--- a/internal/torrent/preset.go
+++ b/internal/torrent/preset.go
@@ -16,13 +16,14 @@ type PresetConfig struct {
 
 // PresetOpts represents the options for a single preset
 type PresetOpts struct {
-	Trackers    []string `yaml:"trackers"`
-	WebSeeds    []string `yaml:"webseeds"`
-	Private     bool     `yaml:"private"`
-	PieceLength uint     `yaml:"piece_length"`
-	Comment     string   `yaml:"comment"`
-	Source      string   `yaml:"source"`
-	NoDate      bool     `yaml:"no_date"`
+	Trackers       []string `yaml:"trackers"`
+	WebSeeds       []string `yaml:"webseeds"`
+	Private        bool     `yaml:"private"`
+	PieceLength    uint     `yaml:"piece_length"`
+	MaxPieceLength uint     `yaml:"max_piece_length"`
+	Comment        string   `yaml:"comment"`
+	Source         string   `yaml:"source"`
+	NoDate         bool     `yaml:"no_date"`
 }
 
 // LoadPresets loads presets from a config file
@@ -69,6 +70,9 @@ func (c *PresetConfig) GetPreset(name string) (*PresetOpts, error) {
 		if preset.PieceLength != 0 {
 			merged.PieceLength = preset.PieceLength
 		}
+		if preset.MaxPieceLength != 0 {
+			merged.MaxPieceLength = preset.MaxPieceLength
+		}
 		if preset.Comment != "" {
 			merged.Comment = preset.Comment
 		}
@@ -113,6 +117,11 @@ func (p *PresetOpts) ToCreateOptions(path string, verbose bool, version string) 
 	if p.PieceLength != 0 {
 		pieceLen := p.PieceLength
 		opts.PieceLengthExp = &pieceLen
+	}
+
+	if p.MaxPieceLength != 0 {
+		maxPieceLen := p.MaxPieceLength
+		opts.MaxPieceLength = &maxPieceLen
 	}
 
 	return opts

--- a/internal/torrent/types.go
+++ b/internal/torrent/types.go
@@ -15,6 +15,7 @@ type CreateTorrentOptions struct {
 	IsPrivate      bool
 	Comment        string
 	PieceLengthExp *uint
+	MaxPieceLength *uint
 	Source         string
 	NoDate         bool
 	Verbose        bool

--- a/schema/presets.json
+++ b/schema/presets.json
@@ -98,6 +98,12 @@
           "no_date": {
             "type": "boolean",
             "description": "Don't write creation date"
+          },
+          "max_piece_length": {
+            "type": "integer",
+            "description": "Maximum piece length as 2^n bytes (14-24)",
+            "minimum": 14,
+            "maximum": 24
           }
         }
       }


### PR DESCRIPTION
This PR adds a max length feature to mkbrr to limit the maximum piece length for a torrent.

EDIT: Documentation had been added.