### PR TITLE
fix(root): silence help text after error

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,6 +40,7 @@ func SetVersion(v, bt string) {
 
 func Execute() error {
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
+	rootCmd.SilenceUsage = true
 
 	rootCmd.AddCommand(versionCmd)
 


### PR DESCRIPTION
Currently if you provide mkbrr with a command that errors it will automatically show the error and the huge help text.
This PR silences / removes the help text after an error occurs.