### PR TITLE
feat: add incomplete season pack detection

### DIFF
--- a/internal/torrent/hasher.go
+++ b/internal/torrent/hasher.go
@@ -20,6 +20,10 @@ type pieceHasher struct {
 	display    Displayer
 	bufferPool *sync.Pool
 	readSize   int
+
+	bytesProcessed int64
+	startTime      time.Time
+	lastUpdate     time.Time
 }
 
 // optimizeForWorkload determines optimal read buffer size and number of worker goroutines
@@ -106,6 +110,21 @@ func (h *pieceHasher) hashPieces(numWorkers int) error {
 		},
 	}
 
+	h.startTime = time.Now()
+	h.lastUpdate = h.startTime
+	h.bytesProcessed = 0
+
+	h.display.ShowFiles(h.files)
+
+	seasonInfo := AnalyzeSeasonPack(h.files)
+
+	if seasonInfo.IsSeasonPack && seasonInfo.VideoFileCount > 1 {
+		if seasonInfo.MaxEpisode > seasonInfo.VideoFileCount {
+			seasonInfo.IsSuspicious = true
+			h.display.ShowSeasonPackWarnings(seasonInfo)
+		}
+	}
+
 	var completedPieces uint64
 	piecesPerWorker := (h.numPieces + numWorkers - 1) / numWorkers
 	errorsCh := make(chan error, numWorkers)
@@ -137,7 +156,15 @@ func (h *pieceHasher) hashPieces(numWorkers int) error {
 			if completed >= uint64(h.numPieces) {
 				break
 			}
-			h.display.UpdateProgress(int(completed))
+
+			bytesProcessed := atomic.LoadInt64(&h.bytesProcessed)
+			elapsed := time.Since(h.startTime).Seconds()
+			var hashrate float64
+			if elapsed > 0 {
+				hashrate = float64(bytesProcessed) / elapsed
+			}
+
+			h.display.UpdateProgress(int(completed), hashrate)
 			time.Sleep(200 * time.Millisecond)
 		}
 	}()
@@ -260,6 +287,8 @@ func (h *pieceHasher) hashPieceRange(startPiece, endPiece int, completedPieces *
 				remainingPiece -= int64(read)
 				reader.position += int64(read)
 				pieceOffset += int64(read)
+
+				atomic.AddInt64(&h.bytesProcessed, int64(read))
 			}
 		}
 

--- a/internal/torrent/hasher_test.go
+++ b/internal/torrent/hasher_test.go
@@ -17,10 +17,12 @@ import (
 // mockDisplay implements Displayer interface for testing
 type mockDisplay struct{}
 
-func (m *mockDisplay) ShowProgress(total int)   {}
-func (m *mockDisplay) UpdateProgress(count int) {}
-func (m *mockDisplay) FinishProgress()          {}
-func (m *mockDisplay) IsBatch() bool            { return true }
+func (m *mockDisplay) ShowProgress(total int)                      {}
+func (m *mockDisplay) UpdateProgress(count int, hashrate float64)  {}
+func (m *mockDisplay) ShowFiles(files []fileEntry)                 {}
+func (m *mockDisplay) ShowSeasonPackWarnings(info *SeasonPackInfo) {}
+func (m *mockDisplay) FinishProgress()                             {}
+func (m *mockDisplay) IsBatch() bool                               { return true }
 
 // TestPieceHasher_Concurrent tests the hasher with various real-world scenarios.
 // Test cases are designed to cover common torrent types and sizes:

--- a/internal/torrent/progress.go
+++ b/internal/torrent/progress.go
@@ -3,7 +3,9 @@ package torrent
 // Displayer defines the interface for displaying progress during torrent creation
 type Displayer interface {
 	ShowProgress(total int)
-	UpdateProgress(completed int)
+	UpdateProgress(completed int, hashrate float64)
+	ShowFiles(files []fileEntry)
+	ShowSeasonPackWarnings(info *SeasonPackInfo)
 	FinishProgress()
 	IsBatch() bool
 }

--- a/internal/torrent/seasonfinder.go
+++ b/internal/torrent/seasonfinder.go
@@ -1,0 +1,168 @@
+package torrent
+
+import (
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type SeasonPackInfo struct {
+	IsSeasonPack    bool
+	Season          int
+	Episodes        []int
+	MissingEpisodes []int
+	MaxEpisode      int
+	VideoFileCount  int
+	IsSuspicious    bool
+}
+
+var seasonPackPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)\.S(\d{1,2})(?:\.|-|_|\s)Complete`),
+	regexp.MustCompile(`(?i)\.Season\.(\d{1,2})\.`),
+	regexp.MustCompile(`(?i)\.S(\d{1,2})(?:\.|-|_|\s)*$`),
+	regexp.MustCompile(`(?i)[-_\s]S(\d{1,2})[-_\s]`),
+	regexp.MustCompile(`(?i)[/\\]Season\s*(\d{1,2})[/\\]`),
+	regexp.MustCompile(`(?i)[/\\]S(\d{1,2})[/\\]`),
+	regexp.MustCompile(`(?i)\.S(\d{1,2})\.(?:\d+p|Complete|COMPLETE)`),
+	regexp.MustCompile(`(?i)Season\s*(\d{1,2})(?:[/\\]|$)`),
+	regexp.MustCompile(`(?i)\.S(\d{1,2})$`),
+}
+
+var episodePattern = regexp.MustCompile(`(?i)S\d{1,2}E(\d{1,3})`)
+var multiEpisodePattern = regexp.MustCompile(`(?i)S\d{1,2}E(\d{1,3})-?E?(\d{1,3})`)
+
+var videoExtensions = map[string]bool{
+	".mkv": true,
+	".mp4": true,
+}
+
+func AnalyzeSeasonPack(files []fileEntry) *SeasonPackInfo {
+	if len(files) == 0 {
+		return &SeasonPackInfo{IsSeasonPack: false}
+	}
+
+	dirPath := filepath.Dir(files[0].path)
+	season := detectSeasonNumber(dirPath)
+
+	if season == 0 && len(files) > 1 {
+		for i := 0; i < minInt(5, len(files)); i++ {
+			if s, _ := extractSeasonEpisode(filepath.Base(files[i].path)); s > 0 {
+				season = s
+				break
+			}
+		}
+	}
+
+	if season == 0 {
+		return &SeasonPackInfo{IsSeasonPack: false}
+	}
+
+	info := &SeasonPackInfo{
+		IsSeasonPack: true,
+		Season:       season,
+		Episodes:     make([]int, 0),
+	}
+
+	episodeMap := make(map[int]bool)
+	for _, file := range files {
+		ext := strings.ToLower(filepath.Ext(file.path))
+		if videoExtensions[ext] {
+			info.VideoFileCount++
+
+			_, episode := extractSeasonEpisode(filepath.Base(file.path))
+			if episode > 0 {
+				episodeMap[episode] = true
+				if episode > info.MaxEpisode {
+					info.MaxEpisode = episode
+				}
+			}
+
+			multiEps := extractMultiEpisodes(filepath.Base(file.path))
+			for _, ep := range multiEps {
+				if ep > 0 {
+					episodeMap[ep] = true
+					if ep > info.MaxEpisode {
+						info.MaxEpisode = ep
+					}
+				}
+			}
+		}
+	}
+
+	for ep := range episodeMap {
+		if ep > 0 {
+			info.Episodes = append(info.Episodes, ep)
+		}
+	}
+	sort.Ints(info.Episodes)
+
+	if info.MaxEpisode > 0 {
+		episodeCount := len(info.Episodes)
+
+		expectedEpisodes := info.MaxEpisode
+
+		info.MissingEpisodes = []int{}
+		for i := 1; i <= info.MaxEpisode; i++ {
+			if !episodeMap[i] {
+				info.MissingEpisodes = append(info.MissingEpisodes, i)
+			}
+		}
+
+		if episodeCount < expectedEpisodes {
+			missingCount := expectedEpisodes - episodeCount
+			percentMissing := float64(missingCount) / float64(expectedEpisodes) * 100
+
+			if (missingCount >= 3 && info.MaxEpisode >= 7) || percentMissing > 50 {
+				info.IsSuspicious = true
+			}
+		}
+	}
+
+	return info
+}
+
+func detectSeasonNumber(path string) int {
+	for _, pattern := range seasonPackPatterns {
+		matches := pattern.FindStringSubmatch(path)
+		if len(matches) > 1 {
+			if season, err := strconv.Atoi(matches[1]); err == nil {
+				return season
+			}
+		}
+	}
+	return 0
+}
+
+func extractSeasonEpisode(filename string) (season, episode int) {
+	epMatches := episodePattern.FindStringSubmatch(filename)
+	if len(epMatches) > 1 {
+		episode, _ = strconv.Atoi(epMatches[1])
+	}
+
+	seasonPattern := regexp.MustCompile(`(?i)S(\d{1,2})`)
+	sMatches := seasonPattern.FindStringSubmatch(filename)
+	if len(sMatches) > 1 {
+		season, _ = strconv.Atoi(sMatches[1])
+	}
+
+	return season, episode
+}
+
+func extractMultiEpisodes(filename string) []int {
+	episodes := []int{}
+
+	matches := multiEpisodePattern.FindStringSubmatch(filename)
+	if len(matches) > 2 {
+		start, err1 := strconv.Atoi(matches[1])
+		end, err2 := strconv.Atoi(matches[2])
+		if err1 == nil && err2 == nil && end >= start {
+			for i := start; i <= end; i++ {
+				episodes = append(episodes, i)
+			}
+		}
+	}
+
+	return episodes
+}

--- a/internal/torrent/seasonfinder_test.go
+++ b/internal/torrent/seasonfinder_test.go
@@ -1,0 +1,74 @@
+package torrent
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectSeasonNumber(t *testing.T) {
+	tests := []struct {
+		path     string
+		expected int
+	}{
+		{filepath.Join("/test", "Dexter.Original.Sin.S01.1080p"), 1},
+		{filepath.Join("/test", "Show.Name.S02.Complete"), 2},
+		{filepath.Join("/test", "Some.Show.Season.03.1080p"), 3},
+		{filepath.Join("/test", "My.Show.S04"), 4},
+		{filepath.Join("/test", "Season 05"), 5},
+		{filepath.Join("/test", "Regular.Movie.2024"), 0},
+	}
+
+	for _, tc := range tests {
+		season := detectSeasonNumber(tc.path)
+		if season != tc.expected {
+			t.Errorf("Expected season %d for path %s, got %d", tc.expected, tc.path, season)
+		}
+	}
+}
+
+func TestExtractSeasonEpisode(t *testing.T) {
+	tests := []struct {
+		filename      string
+		expectSeason  int
+		expectEpisode int
+	}{
+		{"Show.S01E01.Name.mkv", 1, 1},
+		{"S02E05.Episode.Name.mp4", 2, 5},
+		{"My.Show.S03E10.1080p.mkv", 3, 10},
+		{"Movie.2024.mkv", 0, 0}, // Not an episode
+	}
+
+	for _, tc := range tests {
+		season, episode := extractSeasonEpisode(tc.filename)
+		if season != tc.expectSeason || episode != tc.expectEpisode {
+			t.Errorf("For %s expected S%02dE%02d, got S%02dE%02d",
+				tc.filename, tc.expectSeason, tc.expectEpisode, season, episode)
+		}
+	}
+}
+
+func TestMultipleEpisodes(t *testing.T) {
+	tests := []struct {
+		filename         string
+		expectedEpisodes []int
+	}{
+		{"Show.S01E01E02.mkv", []int{1, 2}},
+		{"Show.S01E05-E07.mkv", []int{5, 6, 7}},
+	}
+
+	for _, tc := range tests {
+		episodes := extractMultiEpisodes(tc.filename)
+
+		if len(episodes) != len(tc.expectedEpisodes) {
+			t.Errorf("For %s expected %v episodes, got %v", tc.filename, tc.expectedEpisodes, episodes)
+			continue
+		}
+
+		for i, ep := range episodes {
+			if i < len(tc.expectedEpisodes) && ep != tc.expectedEpisodes[i] {
+				t.Errorf("For %s expected episode %d at position %d, got %d",
+					tc.filename, tc.expectedEpisodes[i], i, ep)
+			}
+		}
+	}
+}


### PR DESCRIPTION
If the input is a folder with a name that indicates that its a pack, it will find the highest number and do a count to look for missing files.

```
mkbrr create ~/Kyles.Original.Sins.S01.1080p.SRC.WEB-DL.DDP5.1.H.264 -t https://tracker.com/announce/1234567

Files being hashed:
  ├─ Kyles.Original.Sins.S01E01.Business.and.Pleasure.1080p.SRC.WEB-DL.DDP5.1.H.264.mkv (3.3 GiB)
  ├─ Kyles.Original.Sins.S01E02.Putting.It.Back.In.1080p.SRC.WEB-DL.DDP5.1.H.264.mkv (3.4 GiB)
  └─ Kyles.Original.Sins.S01E04.Cursor.For.Life.1080p.SRC.WEB-DL.DDP5.1.H.264.mkv (3.3 GiB)


Warning: Possible incomplete season pack detected
  Season number: 1
  Highest episode number found: 4
  Video files: 3

This may be an incomplete season pack. Check files before uploading.

Hashing pieces... [3220.23 MB/s] 100% [========================================]

Wrote title.torrent (elapsed 3.22s)
```