### PR TITLE
feat(output): use tracker domain as prefix

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -34,7 +34,8 @@ var createCmd = &cobra.Command{
 	Short: "Create a new torrent file",
 	Long: `Create a new torrent file from a file or directory.
 Supports both single file/directory and batch mode using a YAML config file.
-Supports presets for commonly used settings.`,
+Supports presets for commonly used settings.
+When a tracker URL is provided, the output filename will use the tracker domain (without TLD) as prefix, e.g. "example_filename.torrent".`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) > 1 {
 			return fmt.Errorf("accepts at most one arg")

--- a/cmd/modify.go
+++ b/cmd/modify.go
@@ -12,6 +12,7 @@ var (
 	modifyPresetName string
 	modifyPresetFile string
 	modifyOutputDir  string
+	modifyOutput     string
 	modifyDryRun     bool
 	modifyNoDate     bool
 	modifyNoCreator  bool
@@ -28,7 +29,8 @@ var modifyCmd = &cobra.Command{
 	Short: "Modify existing torrent files using a preset",
 	Long: `Modify existing torrent files using a preset or flags.
 This allows batch modification of torrent files with new tracker URLs, source tags, etc.
-Original files are preserved and new files are created with -[preset] or -modified suffix.
+Original files are preserved and new files are created with the tracker domain (without TLD) as prefix, e.g. "example_filename.torrent".
+A custom output filename can also be specified via --output.
 
 Note: All unnecessary metadata will be stripped.`,
 	Args:                  cobra.MinimumNArgs(1),
@@ -49,6 +51,7 @@ func init() {
 	modifyCmd.Flags().StringVarP(&modifyPresetName, "preset", "P", "", "use preset from config")
 	modifyCmd.Flags().StringVar(&modifyPresetFile, "preset-file", "", "preset config file (default: ~/.config/mkbrr/presets.yaml)")
 	modifyCmd.Flags().StringVar(&modifyOutputDir, "output-dir", "", "output directory for modified files")
+	modifyCmd.Flags().StringVarP(&modifyOutput, "output", "o", "", "custom output filename (without extension)")
 	modifyCmd.Flags().BoolVarP(&modifyNoDate, "no-date", "d", false, "don't update creation date")
 	modifyCmd.Flags().BoolVarP(&modifyNoCreator, "no-creator", "", false, "don't write creator")
 	modifyCmd.Flags().StringVarP(&modifyTracker, "tracker", "t", "", "tracker URL")
@@ -75,18 +78,19 @@ func runModify(cmd *cobra.Command, args []string) error {
 
 	// build opts, including our override flags defined above
 	opts := torrent.Options{
-		PresetName: modifyPresetName,
-		PresetFile: modifyPresetFile,
-		OutputDir:  modifyOutputDir,
-		NoDate:     modifyNoDate,
-		NoCreator:  modifyNoCreator,
-		DryRun:     modifyDryRun,
-		Verbose:    modifyVerbose,
-		TrackerURL: modifyTracker,
-		WebSeeds:   modifyWebSeeds,
-		Comment:    modifyComment,
-		Source:     modifySource,
-		Version:    version,
+		PresetName:    modifyPresetName,
+		PresetFile:    modifyPresetFile,
+		OutputDir:     modifyOutputDir,
+		OutputPattern: modifyOutput,
+		NoDate:        modifyNoDate,
+		NoCreator:     modifyNoCreator,
+		DryRun:        modifyDryRun,
+		Verbose:       modifyVerbose,
+		TrackerURL:    modifyTracker,
+		WebSeeds:      modifyWebSeeds,
+		Comment:       modifyComment,
+		Source:        modifySource,
+		Version:       version,
 	}
 
 	if cmd.Flags().Changed("private") {

--- a/internal/preset/preset.go
+++ b/internal/preset/preset.go
@@ -218,8 +218,56 @@ func (o *Options) ApplyToMetaInfo(mi *metainfo.MetaInfo) (bool, error) {
 	return wasModified, nil
 }
 
+// GetDomainPrefix extracts a clean domain name from a tracker URL to use as a filename prefix
+func GetDomainPrefix(trackerURL string) string {
+	if trackerURL == "" {
+		return "modified"
+	}
+
+	cleanURL := strings.TrimSpace(trackerURL)
+
+	domain := cleanURL
+
+	if strings.Contains(domain, "://") {
+		parts := strings.SplitN(domain, "://", 2)
+		if len(parts) == 2 {
+			domain = parts[1]
+		}
+	}
+
+	if strings.Contains(domain, "/") {
+		domain = strings.SplitN(domain, "/", 2)[0]
+	}
+
+	if strings.Contains(domain, ":") {
+		domain = strings.SplitN(domain, ":", 2)[0]
+	}
+
+	domain = strings.TrimPrefix(domain, "www.")
+
+	if domain != "" {
+		parts := strings.Split(domain, ".")
+
+		if len(parts) > 1 {
+			// take only the domain name without TLD
+			// for example, from "tracker.example.com", get "example"
+			if len(parts) > 2 {
+				// for subdomains, use the second-to-last part
+				domain = parts[len(parts)-2]
+			} else {
+				// for simple domains like example.com, use the first part
+				domain = parts[0]
+			}
+		}
+
+		return sanitizeFilename(domain)
+	}
+
+	return "modified"
+}
+
 // GenerateOutputPath generates an output path for a modified torrent file
-func GenerateOutputPath(originalPath, outputDir, presetName string) string {
+func GenerateOutputPath(originalPath, outputDir, presetName string, outputPattern string, trackerURL string) string {
 	dir := filepath.Dir(originalPath)
 	if outputDir != "" {
 		dir = outputDir
@@ -229,11 +277,34 @@ func GenerateOutputPath(originalPath, outputDir, presetName string) string {
 	ext := filepath.Ext(base)
 	name := strings.TrimSuffix(base, ext)
 
-	// add preset name or "modified" to filename
-	suffix := "-modified"
-	if presetName != "" {
-		suffix = "-" + presetName
+	// if custom output pattern is provided, use it
+	if outputPattern != "" {
+		return filepath.Join(dir, outputPattern+ext)
 	}
 
-	return filepath.Join(dir, name+suffix+ext)
+	prefix := GetDomainPrefix(trackerURL)
+
+	if trackerURL == "" && presetName != "" {
+		prefix = sanitizeFilename(presetName)
+	}
+
+	return filepath.Join(dir, prefix+"_"+name+ext)
+}
+
+// sanitizeFilename removes characters that are invalid in filenames
+func sanitizeFilename(input string) string {
+	// replace characters that are problematic in filenames
+	replacer := strings.NewReplacer(
+		"/", "_",
+		"\\", "_",
+		":", "_",
+		"*", "_",
+		"?", "_",
+		"\"", "_",
+		"<", "_",
+		">", "_",
+		"|", "_",
+		" ", "_",
+	)
+	return replacer.Replace(input)
 }

--- a/internal/preset/preset.go
+++ b/internal/preset/preset.go
@@ -267,7 +267,7 @@ func GetDomainPrefix(trackerURL string) string {
 }
 
 // GenerateOutputPath generates an output path for a modified torrent file
-func GenerateOutputPath(originalPath, outputDir, presetName string, outputPattern string, trackerURL string) string {
+func GenerateOutputPath(originalPath, outputDir, presetName string, outputPattern string, trackerURL string, metaInfoName string) string {
 	dir := filepath.Dir(originalPath)
 	if outputDir != "" {
 		dir = outputDir
@@ -275,7 +275,11 @@ func GenerateOutputPath(originalPath, outputDir, presetName string, outputPatter
 
 	base := filepath.Base(originalPath)
 	ext := filepath.Ext(base)
+
 	name := strings.TrimSuffix(base, ext)
+	if metaInfoName != "" {
+		name = metaInfoName
+	}
 
 	// if custom output pattern is provided, use it
 	if outputPattern != "" {

--- a/internal/torrent/batch.go
+++ b/internal/torrent/batch.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/autobrr/mkbrr/internal/preset"
 	"gopkg.in/yaml.v3"
 )
 
@@ -147,8 +148,24 @@ func processJob(job BatchJob, verbose bool, version string) BatchResult {
 		Trackers: job.Trackers,
 	}
 
-	// ensure output has .torrent extension
+	var trackerURL string
+	if len(job.Trackers) > 0 {
+		trackerURL = job.Trackers[0]
+	}
+
 	output := job.Output
+	if output == "" {
+		baseName := filepath.Base(filepath.Clean(job.Path))
+
+		if trackerURL != "" {
+			prefix := preset.GetDomainPrefix(trackerURL)
+			baseName = prefix + "_" + baseName
+		}
+
+		output = baseName
+	}
+
+	// ensure output has .torrent extension
 	if filepath.Ext(output) != ".torrent" {
 		output += ".torrent"
 	}

--- a/internal/torrent/create.go
+++ b/internal/torrent/create.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/anacrolix/torrent/bencode"
 	"github.com/anacrolix/torrent/metainfo"
+	"github.com/autobrr/mkbrr/internal/preset"
 	"github.com/autobrr/mkbrr/internal/trackers"
 )
 
@@ -357,9 +358,12 @@ func Create(opts CreateTorrentOptions) (*TorrentInfo, error) {
 		opts.Name = filepath.Base(filepath.Clean(opts.Path))
 	}
 
-	// set output path if not provided
 	if opts.OutputPath == "" {
-		opts.OutputPath = opts.Name + ".torrent"
+		fileName := opts.Name
+		if opts.TrackerURL != "" {
+			fileName = preset.GetDomainPrefix(opts.TrackerURL) + "_" + opts.Name
+		}
+		opts.OutputPath = fileName + ".torrent"
 	} else if !strings.HasSuffix(opts.OutputPath, ".torrent") {
 		opts.OutputPath = opts.OutputPath + ".torrent"
 	}

--- a/internal/torrent/modify.go
+++ b/internal/torrent/modify.go
@@ -16,6 +16,7 @@ type Options struct {
 	PresetName     string
 	PresetFile     string
 	OutputDir      string
+	OutputPattern  string
 	NoDate         bool
 	NoCreator      bool
 	DryRun         bool
@@ -168,7 +169,7 @@ func ModifyTorrent(path string, opts Options) (*Result, error) {
 	}
 
 	// generate output path using the preset generating helper
-	outPath := preset.GenerateOutputPath(path, opts.OutputDir, opts.PresetName)
+	outPath := preset.GenerateOutputPath(path, opts.OutputDir, opts.PresetName, opts.OutputPattern, opts.TrackerURL)
 	result.OutputPath = outPath
 
 	// ensure output directory exists if specified

--- a/internal/torrent/modify.go
+++ b/internal/torrent/modify.go
@@ -168,8 +168,14 @@ func ModifyTorrent(path string, opts Options) (*Result, error) {
 		return result, nil
 	}
 
+	var metaInfoName string
+	info, err := mi.UnmarshalInfo()
+	if err == nil {
+		metaInfoName = info.Name
+	}
+
 	// generate output path using the preset generating helper
-	outPath := preset.GenerateOutputPath(path, opts.OutputDir, opts.PresetName, opts.OutputPattern, opts.TrackerURL)
+	outPath := preset.GenerateOutputPath(path, opts.OutputDir, opts.PresetName, opts.OutputPattern, opts.TrackerURL, metaInfoName)
 	result.OutputPath = outPath
 
 	// ensure output directory exists if specified


### PR DESCRIPTION
## Changes

Improves torrent file naming by:

- Adding a new `-o/--output` flag for custom output filenames to the modify command
- Changing the naming convention to use the tracker domain as a prefix instead of a suffix
- Extracting domain names from tracker URLs (without TLD) for cleaner filenames
- Applying consistent naming across `create`, `modify`, and `batch` commands

## Examples

Before:
- `filename-modified.torrent` (default)
- `filename-presetname.torrent` (when using preset)

After:
- `example_filename.torrent` (when using tracker test.example.com)
- `customname.torrent` (when using --output flag)
- `filename.torrent` (when no trackerUrl is provided)