### PR TITLE
feat: add randomized info hash support via entropy flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ mkbrr create path/to/file -t https://example-tracker.com/announce
 # public torrent
 mkbrr create path/to/file -t https://example-tracker.com/announce --private=false
 
-# Create with randomized info hash (for cross-seeding)
-mkbrr create path/to/file -t https://example-tracker.com/announce -x
+# Create with randomized info hash
+mkbrr create path/to/file -t https://example-tracker.com/announce -e
 ```
 
 ## Table of Contents
@@ -158,8 +158,8 @@ mkbrr create path/to/file -t https://example-tracker.com/announce -c "My awesome
 # Create with a custom output path
 mkbrr create path/to/file -t https://example-tracker.com/announce -o custom-name.torrent
 
-# Create with randomized info hash (for cross-seeding)
-mkbrr create path/to/file -t https://example-tracker.com/announce -x
+# Create with randomized info hash
+mkbrr create path/to/file -t https://example-tracker.com/announce -e
 ```
 
 ### Inspecting Torrents
@@ -191,8 +191,8 @@ mkbrr modify *.torrent --private=false
 # See what would be changed without making actual changes
 mkbrr modify original.torrent --tracker https://new-tracker.com --dry-run
 
-# Randomize info hash for cross-seeding
-mkbrr modify original.torrent -x
+# Randomize info hash
+mkbrr modify original.torrent -e
 ```
 
 ## Advanced Usage

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Flags:
   -h, --help   help for mkbrr
 
 Use "mkbrr [command] --help" for more information about a command.
-````
+```
 
 ## What is mkbrr?
 
@@ -64,6 +64,9 @@ mkbrr create path/to/file -t https://example-tracker.com/announce
 
 # public torrent
 mkbrr create path/to/file -t https://example-tracker.com/announce --private=false
+
+# Create with randomized info hash (for cross-seeding)
+mkbrr create path/to/file -t https://example-tracker.com/announce -x
 ```
 
 ## Table of Contents
@@ -154,6 +157,9 @@ mkbrr create path/to/file -t https://example-tracker.com/announce -c "My awesome
 
 # Create with a custom output path
 mkbrr create path/to/file -t https://example-tracker.com/announce -o custom-name.torrent
+
+# Create with randomized info hash (for cross-seeding)
+mkbrr create path/to/file -t https://example-tracker.com/announce -x
 ```
 
 ### Inspecting Torrents
@@ -184,6 +190,9 @@ mkbrr modify *.torrent --private=false
 
 # See what would be changed without making actual changes
 mkbrr modify original.torrent --tracker https://new-tracker.com --dry-run
+
+# Randomize info hash for cross-seeding
+mkbrr modify original.torrent -x
 ```
 
 ## Advanced Usage

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -27,6 +27,7 @@ var (
 	batchFile         string
 	presetName        string
 	presetFile        string
+	xseed             bool
 )
 
 var createCmd = &cobra.Command{
@@ -95,6 +96,7 @@ func init() {
 	createCmd.Flags().StringVarP(&source, "source", "s", "", "add source string")
 	createCmd.Flags().BoolVarP(&noDate, "no-date", "d", false, "don't write creation date")
 	createCmd.Flags().BoolVarP(&noCreator, "no-creator", "", false, "don't write creator")
+	createCmd.Flags().BoolVarP(&xseed, "xseed", "x", false, "randomize info hash by adding entropy field")
 	createCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "be verbose")
 
 	createCmd.Flags().String("cpuprofile", "", "write cpu profile to file (development flag)")
@@ -204,6 +206,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 			NoCreator:  presetOpts.NoCreator != nil && *presetOpts.NoCreator,
 			Verbose:    verbose,
 			Version:    version,
+			Xseed:      xseed,
 		}
 
 		if presetOpts.PieceLength != 0 {
@@ -259,6 +262,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 			NoCreator:      noCreator,
 			Verbose:        verbose,
 			Version:        version,
+			Xseed:          xseed,
 		}
 	}
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -27,7 +27,7 @@ var (
 	batchFile         string
 	presetName        string
 	presetFile        string
-	xseed             bool
+	entropy           bool
 )
 
 var createCmd = &cobra.Command{
@@ -96,7 +96,7 @@ func init() {
 	createCmd.Flags().StringVarP(&source, "source", "s", "", "add source string")
 	createCmd.Flags().BoolVarP(&noDate, "no-date", "d", false, "don't write creation date")
 	createCmd.Flags().BoolVarP(&noCreator, "no-creator", "", false, "don't write creator")
-	createCmd.Flags().BoolVarP(&xseed, "xseed", "x", false, "randomize info hash by adding entropy field")
+	createCmd.Flags().BoolVarP(&entropy, "entropy", "e", false, "randomize info hash by adding entropy field")
 	createCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "be verbose")
 
 	createCmd.Flags().String("cpuprofile", "", "write cpu profile to file (development flag)")
@@ -206,7 +206,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 			NoCreator:  presetOpts.NoCreator != nil && *presetOpts.NoCreator,
 			Verbose:    verbose,
 			Version:    version,
-			Xseed:      xseed,
+			Entropy:    entropy,
 		}
 
 		if presetOpts.PieceLength != 0 {
@@ -262,7 +262,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 			NoCreator:      noCreator,
 			Verbose:        verbose,
 			Version:        version,
-			Xseed:          xseed,
+			Entropy:        entropy,
 		}
 	}
 

--- a/cmd/modify.go
+++ b/cmd/modify.go
@@ -22,7 +22,7 @@ var (
 	modifyPrivate    bool = true // default to true like create
 	modifyComment    string
 	modifySource     string
-	modifyXseed      bool
+	modifyEntropy    bool
 )
 
 var modifyCmd = &cobra.Command{
@@ -60,7 +60,7 @@ func init() {
 	modifyCmd.Flags().BoolVarP(&modifyPrivate, "private", "p", true, "make torrent private (default: true)")
 	modifyCmd.Flags().StringVarP(&modifyComment, "comment", "c", "", "add comment")
 	modifyCmd.Flags().StringVarP(&modifySource, "source", "s", "", "add source string")
-	modifyCmd.Flags().BoolVarP(&modifyXseed, "xseed", "x", false, "randomize info hash by adding entropy field")
+	modifyCmd.Flags().BoolVarP(&modifyEntropy, "entropy", "e", false, "randomize info hash by adding entropy field")
 	modifyCmd.Flags().BoolVarP(&modifyVerbose, "verbose", "v", false, "be verbose")
 	modifyCmd.Flags().BoolVarP(&modifyDryRun, "dry-run", "n", false, "show what would be modified without making changes")
 
@@ -93,7 +93,7 @@ func runModify(cmd *cobra.Command, args []string) error {
 		Comment:       modifyComment,
 		Source:        modifySource,
 		Version:       version,
-		Xseed:         modifyXseed,
+		Entropy:       modifyEntropy,
 	}
 
 	if cmd.Flags().Changed("private") {

--- a/cmd/modify.go
+++ b/cmd/modify.go
@@ -22,6 +22,7 @@ var (
 	modifyPrivate    bool = true // default to true like create
 	modifyComment    string
 	modifySource     string
+	modifyXseed      bool
 )
 
 var modifyCmd = &cobra.Command{
@@ -59,6 +60,7 @@ func init() {
 	modifyCmd.Flags().BoolVarP(&modifyPrivate, "private", "p", true, "make torrent private (default: true)")
 	modifyCmd.Flags().StringVarP(&modifyComment, "comment", "c", "", "add comment")
 	modifyCmd.Flags().StringVarP(&modifySource, "source", "s", "", "add source string")
+	modifyCmd.Flags().BoolVarP(&modifyXseed, "xseed", "x", false, "randomize info hash by adding entropy field")
 	modifyCmd.Flags().BoolVarP(&modifyVerbose, "verbose", "v", false, "be verbose")
 	modifyCmd.Flags().BoolVarP(&modifyDryRun, "dry-run", "n", false, "show what would be modified without making changes")
 
@@ -91,6 +93,7 @@ func runModify(cmd *cobra.Command, args []string) error {
 		Comment:       modifyComment,
 		Source:        modifySource,
 		Version:       version,
+		Xseed:         modifyXseed,
 	}
 
 	if cmd.Flags().Changed("private") {

--- a/internal/torrent/create.go
+++ b/internal/torrent/create.go
@@ -248,7 +248,7 @@ func CreateTorrent(opts CreateTorrentOptions) (*Torrent, error) {
 		}
 
 		// add random entropy field for cross-seeding if enabled
-		if opts.Xseed {
+		if opts.Entropy {
 			infoMap := make(map[string]interface{})
 			if err := bencode.Unmarshal(infoBytes, &infoMap); err == nil {
 				var entropy int64

--- a/internal/torrent/create.go
+++ b/internal/torrent/create.go
@@ -2,7 +2,6 @@ package torrent
 
 import (
 	"crypto/rand"
-	"encoding/binary"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -128,6 +127,14 @@ func (t *Torrent) GetInfo() *metainfo.Info {
 	return info
 }
 
+func generateRandomString() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", b), nil
+}
+
 func CreateTorrent(opts CreateTorrentOptions) (*Torrent, error) {
 	path := filepath.ToSlash(opts.Path)
 	name := opts.Name
@@ -251,8 +258,7 @@ func CreateTorrent(opts CreateTorrentOptions) (*Torrent, error) {
 		if opts.Entropy {
 			infoMap := make(map[string]interface{})
 			if err := bencode.Unmarshal(infoBytes, &infoMap); err == nil {
-				var entropy int64
-				if err := binary.Read(rand.Reader, binary.BigEndian, &entropy); err == nil {
+				if entropy, err := generateRandomString(); err == nil {
 					infoMap["entropy"] = entropy
 					if infoBytes, err = bencode.Marshal(infoMap); err == nil {
 						mi.InfoBytes = infoBytes

--- a/internal/torrent/modify.go
+++ b/internal/torrent/modify.go
@@ -31,7 +31,7 @@ type Options struct {
 	MaxPieceLength *uint
 	Source         string
 	Version        string
-	Xseed          bool
+	Entropy        bool
 }
 
 // Result represents the result of modifying a torrent
@@ -148,7 +148,7 @@ func ModifyTorrent(path string, opts Options) (*Result, error) {
 	}
 
 	// add random entropy field for cross-seeding if enabled
-	if opts.Xseed {
+	if opts.Entropy {
 		infoMap := make(map[string]interface{})
 		if err := bencode.Unmarshal(mi.InfoBytes, &infoMap); err == nil {
 			var entropy int64

--- a/internal/torrent/modify.go
+++ b/internal/torrent/modify.go
@@ -1,8 +1,6 @@
 package torrent
 
 import (
-	"crypto/rand"
-	"encoding/binary"
 	"fmt"
 	"os"
 	"time"
@@ -151,8 +149,7 @@ func ModifyTorrent(path string, opts Options) (*Result, error) {
 	if opts.Entropy {
 		infoMap := make(map[string]interface{})
 		if err := bencode.Unmarshal(mi.InfoBytes, &infoMap); err == nil {
-			var entropy int64
-			if err := binary.Read(rand.Reader, binary.BigEndian, &entropy); err == nil {
+			if entropy, err := generateRandomString(); err == nil {
 				infoMap["entropy"] = entropy
 				if infoBytes, err := bencode.Marshal(infoMap); err == nil {
 					mi.InfoBytes = infoBytes

--- a/internal/torrent/types.go
+++ b/internal/torrent/types.go
@@ -22,6 +22,7 @@ type CreateTorrentOptions struct {
 	Verbose        bool
 	Version        string
 	OutputPath     string
+	Xseed          bool
 }
 
 // Torrent represents a torrent file with additional functionality

--- a/internal/torrent/types.go
+++ b/internal/torrent/types.go
@@ -22,7 +22,7 @@ type CreateTorrentOptions struct {
 	Verbose        bool
 	Version        string
 	OutputPath     string
-	Xseed          bool
+	Entropy        bool
 }
 
 // Torrent represents a torrent file with additional functionality


### PR DESCRIPTION
Adds a new `-e/--entropy` flag to both create and modify commands that randomizes the info hash by adding an entropy field to the info dictionary.


I really don't see the point of this yet, unless some trackers e.g. actively cleans the source field. 