### PR TITLE
feat(create): support exclude patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,16 @@ mkbrr create path/to/file -t https://example-tracker.com/announce -o custom-name
 
 # Create with randomized info hash
 mkbrr create path/to/file -t https://example-tracker.com/announce -e
+
+# Create a torrent excluding specific file patterns (comma-separated)
+mkbrr create path/to/file -t https://example-tracker.com/announce --exclude "*.nfo,*.jpg"
+
+# Exclude multiple patterns using separate flags
+mkbrr create path/to/file -t https://example-tracker.com/announce --exclude "*.nfo" --exclude "*sample*"
 ```
+
+> [!NOTE]
+> The exclude patterns feature supports standard glob pattern matching (like `*` for any number of characters, `?` for a single character) and is case-insensitive.
 
 ### Inspecting Torrents
 
@@ -212,7 +221,7 @@ mkbrr create -P ptp --source "MySource" path/to/file
 ```
 
 > [!TIP]
-> The preset file can be placed in the current directory, `~/.config/mkbrr/`, or `~/.mkbrr/`. You can also specify a custom location with `--preset-file`.
+> The preset file can be placed in the current directory, `~/.config/mkbrr/`, or `~/.mkbrr/`. You can also specify a custom location with `--preset-file`. Presets also support the `exclude_patterns` field, allowing you to define default or preset-specific file exclusions.
 
 ### Batch Mode
 
@@ -223,6 +232,21 @@ mkbrr create -b batch.yaml
 ```
 
 See [batch example](examples/batch.yaml) here.
+
+Batch mode also supports excluding file patterns via the `exclude_patterns` field. This is useful for automatically filtering unwanted files like NFOs, samples, or image files.
+
+```yaml
+# Example batch.yaml snippet showing exclude_patterns
+jobs:
+  - output: example.torrent
+    path: /path/to/content
+    trackers:
+      - https://example-tracker.com/announce
+    exclude_patterns:
+      - "*.nfo"
+      - "*.jpg"
+      - "*sample*"
+```
 
 > [!TIP]
 > Batch mode processes jobs in parallel (up to 4 at once) and shows a summary when complete.

--- a/README.md
+++ b/README.md
@@ -163,9 +163,6 @@ mkbrr create path/to/file -t https://example-tracker.com/announce -e
 
 # Create a torrent excluding specific file patterns (comma-separated)
 mkbrr create path/to/file -t https://example-tracker.com/announce --exclude "*.nfo,*.jpg"
-
-# Exclude multiple patterns using separate flags
-mkbrr create path/to/file -t https://example-tracker.com/announce --exclude "*.nfo" --exclude "*sample*"
 ```
 
 > [!NOTE]
@@ -221,7 +218,7 @@ mkbrr create -P ptp --source "MySource" path/to/file
 ```
 
 > [!TIP]
-> The preset file can be placed in the current directory, `~/.config/mkbrr/`, or `~/.mkbrr/`. You can also specify a custom location with `--preset-file`. Presets also support the `exclude_patterns` field, allowing you to define default or preset-specific file exclusions.
+> The preset file can be placed in the current directory, `~/.config/mkbrr/`, or `~/.mkbrr/`. You can also specify a custom location with `--preset-file`. Presets support the `exclude_patterns` field, allowing you to define default or preset-specific file exclusions.
 
 ### Batch Mode
 
@@ -233,23 +230,8 @@ mkbrr create -b batch.yaml
 
 See [batch example](examples/batch.yaml) here.
 
-Batch mode also supports excluding file patterns via the `exclude_patterns` field. This is useful for automatically filtering unwanted files like NFOs, samples, or image files.
-
-```yaml
-# Example batch.yaml snippet showing exclude_patterns
-jobs:
-  - output: example.torrent
-    path: /path/to/content
-    trackers:
-      - https://example-tracker.com/announce
-    exclude_patterns:
-      - "*.nfo"
-      - "*.jpg"
-      - "*sample*"
-```
-
 > [!TIP]
-> Batch mode processes jobs in parallel (up to 4 at once) and shows a summary when complete.
+> Batch mode processes jobs in parallel (up to 4 at once) and shows a summary when complete. Batch mode also support the `exclude_patterns` field.
 
 ## Tracker-Specific Features
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -29,6 +29,7 @@ var (
 	presetFile        string
 	entropy           bool
 	quiet             bool
+	excludePatterns   []string
 )
 
 var createCmd = &cobra.Command{
@@ -100,6 +101,7 @@ func init() {
 	createCmd.Flags().BoolVarP(&entropy, "entropy", "e", false, "randomize info hash by adding entropy field")
 	createCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "be verbose")
 	createCmd.Flags().BoolVar(&quiet, "quiet", false, "reduced output mode (prints only final torrent path)")
+	createCmd.Flags().StringArrayVarP(&excludePatterns, "exclude", "", nil, "exclude files matching these patterns (e.g., \"*.nfo,*.jpg\" or -e \"*.nfo\" -e \"*.jpg\")")
 
 	createCmd.Flags().String("cpuprofile", "", "write cpu profile to file (development flag)")
 
@@ -207,18 +209,23 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 		// convert preset to options
 		opts = torrent.CreateTorrentOptions{
-			Path:       inputPath,
-			TrackerURL: presetOpts.Trackers[0],
-			WebSeeds:   presetOpts.WebSeeds,
-			IsPrivate:  *presetOpts.Private,
-			Comment:    presetOpts.Comment,
-			Source:     presetOpts.Source,
-			NoDate:     presetOpts.NoDate != nil && *presetOpts.NoDate,
-			NoCreator:  presetOpts.NoCreator != nil && *presetOpts.NoCreator,
-			Verbose:    verbose,
-			Version:    version,
-			Entropy:    entropy,
-			Quiet:      quiet,
+			Path:            inputPath,
+			TrackerURL:      presetOpts.Trackers[0],
+			WebSeeds:        presetOpts.WebSeeds,
+			IsPrivate:       *presetOpts.Private,
+			Comment:         presetOpts.Comment,
+			Source:          presetOpts.Source,
+			NoDate:          presetOpts.NoDate != nil && *presetOpts.NoDate,
+			NoCreator:       presetOpts.NoCreator != nil && *presetOpts.NoCreator,
+			Verbose:         verbose,
+			Version:         version,
+			Entropy:         entropy,
+			Quiet:           quiet,
+			ExcludePatterns: excludePatterns,
+		}
+
+		if !cmd.Flags().Changed("exclude") && len(presetOpts.ExcludePatterns) > 0 {
+			opts.ExcludePatterns = presetOpts.ExcludePatterns
 		}
 
 		if presetOpts.PieceLength != 0 {
@@ -259,23 +266,27 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		if cmd.Flags().Changed("no-creator") {
 			opts.NoCreator = noCreator
 		}
+		if cmd.Flags().Changed("exclude") {
+			opts.ExcludePatterns = excludePatterns
+		}
 	} else {
 		// use command line options
 		opts = torrent.CreateTorrentOptions{
-			Path:           inputPath,
-			TrackerURL:     trackerURL,
-			WebSeeds:       webSeeds,
-			IsPrivate:      isPrivate,
-			Comment:        comment,
-			PieceLengthExp: pieceLengthExp,
-			MaxPieceLength: maxPieceLengthExp,
-			Source:         source,
-			NoDate:         noDate,
-			NoCreator:      noCreator,
-			Verbose:        verbose,
-			Version:        version,
-			Entropy:        entropy,
-			Quiet:          quiet,
+			Path:            inputPath,
+			TrackerURL:      trackerURL,
+			WebSeeds:        webSeeds,
+			IsPrivate:       isPrivate,
+			Comment:         comment,
+			PieceLengthExp:  pieceLengthExp,
+			MaxPieceLength:  maxPieceLengthExp,
+			Source:          source,
+			NoDate:          noDate,
+			NoCreator:       noCreator,
+			Verbose:         verbose,
+			Version:         version,
+			Entropy:         entropy,
+			Quiet:           quiet,
+			ExcludePatterns: excludePatterns,
 		}
 	}
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -10,6 +10,7 @@ import (
 	"github.com/autobrr/mkbrr/internal/preset"
 	"github.com/autobrr/mkbrr/internal/torrent"
 	"github.com/spf13/cobra"
+	"golang.org/x/exp/slices"
 )
 
 var (
@@ -224,11 +225,11 @@ func runCreate(cmd *cobra.Command, args []string) error {
 			Version:         version,
 			Entropy:         entropy,
 			Quiet:           quiet,
-			ExcludePatterns: excludePatterns,
+			ExcludePatterns: []string{},
 		}
 
-		if !cmd.Flags().Changed("exclude") && len(presetOpts.ExcludePatterns) > 0 {
-			opts.ExcludePatterns = presetOpts.ExcludePatterns
+		if len(presetOpts.ExcludePatterns) > 0 {
+			opts.ExcludePatterns = slices.Clone(presetOpts.ExcludePatterns)
 		}
 
 		if presetOpts.PieceLength != 0 {
@@ -273,7 +274,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 			opts.SkipPrefix = skipPrefix
 		}
 		if cmd.Flags().Changed("exclude") {
-			opts.ExcludePatterns = excludePatterns
+			opts.ExcludePatterns = append(opts.ExcludePatterns, excludePatterns...)
 		}
 	} else {
 		// use command line options

--- a/examples/batch.yaml
+++ b/examples/batch.yaml
@@ -15,3 +15,6 @@ jobs:
     private: true
     source: "anothertracker"
     no_date: true
+    exclude_patterns: # Example: exclude NFO files and samples
+      - "*.nfo"
+      - "*sample*"

--- a/examples/presets.yaml
+++ b/examples/presets.yaml
@@ -8,12 +8,18 @@ default:
   no_creator: false
   # comment: "Default comment for all torrents"  # Torrent comment
   # source: "DEFAULT"                           # Source tag
+  # exclude_patterns:                           # Default list of glob patterns to exclude files
+  #   - "*.bak"
+  #   - "temp.*"
 
 presets:
   ptp:
     source: "PTP"
     trackers:
       - "https://please.passthe.tea/announce"
+    exclude_patterns: # Example: exclude NFO files and samples
+      - "*.nfo"
+      - "*sample*"
 
   # Public tracker preset with all options shown
   public:

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/rhysd/go-github-selfupdate v1.2.3
 	github.com/schollz/progressbar/v3 v3.18.0
 	github.com/spf13/cobra v1.9.1
+	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -39,7 +40,6 @@ require (
 	github.com/tcnksm/go-gitconfig v0.1.2 // indirect
 	github.com/ulikunitz/xz v0.5.9 // indirect
 	golang.org/x/crypto v0.32.0 // indirect
-	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 // indirect
 	golang.org/x/net v0.29.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421 // indirect
 	golang.org/x/sys v0.30.0 // indirect

--- a/internal/preset/preset.go
+++ b/internal/preset/preset.go
@@ -21,16 +21,17 @@ type Config struct {
 
 // Options represents the options for a single preset
 type Options struct {
-	Trackers       []string `yaml:"trackers"`
-	WebSeeds       []string `yaml:"webseeds"`
-	Private        *bool    `yaml:"private"`
-	PieceLength    uint     `yaml:"piece_length"`
-	MaxPieceLength uint     `yaml:"max_piece_length"`
-	Comment        string   `yaml:"comment"`
-	Source         string   `yaml:"source"`
-	NoDate         *bool    `yaml:"no_date"`
-	NoCreator      *bool    `yaml:"no_creator"`
-	Version        string   // used for creator string
+	Trackers        []string `yaml:"trackers"`
+	WebSeeds        []string `yaml:"webseeds"`
+	Private         *bool    `yaml:"private"`
+	PieceLength     uint     `yaml:"piece_length"`
+	MaxPieceLength  uint     `yaml:"max_piece_length"`
+	Comment         string   `yaml:"comment"`
+	Source          string   `yaml:"source"`
+	NoDate          *bool    `yaml:"no_date"`
+	NoCreator       *bool    `yaml:"no_creator"`
+	ExcludePatterns []string `yaml:"exclude_patterns"`
+	Version         string   // used for creator string
 }
 
 // FindPresetFile searches for a preset file in known locations
@@ -117,6 +118,9 @@ func (c *Config) GetPreset(name string) (*Options, error) {
 		merged.Source = c.Default.Source
 		merged.PieceLength = c.Default.PieceLength
 		merged.MaxPieceLength = c.Default.MaxPieceLength
+		if len(c.Default.ExcludePatterns) > 0 {
+			merged.ExcludePatterns = c.Default.ExcludePatterns
+		}
 	}
 
 	// override with preset values if they are set
@@ -146,6 +150,9 @@ func (c *Config) GetPreset(name string) (*Options, error) {
 	}
 	if preset.NoCreator != nil {
 		merged.NoCreator = preset.NoCreator
+	}
+	if len(preset.ExcludePatterns) > 0 {
+		merged.ExcludePatterns = preset.ExcludePatterns
 	}
 
 	return &merged, nil

--- a/internal/torrent/batch.go
+++ b/internal/torrent/batch.go
@@ -18,16 +18,17 @@ type BatchConfig struct {
 
 // BatchJob represents a single torrent creation job within a batch
 type BatchJob struct {
-	Output      string   `yaml:"output"`
-	Path        string   `yaml:"path"`
-	Name        string   `yaml:"-"`
-	Trackers    []string `yaml:"trackers"`
-	WebSeeds    []string `yaml:"webseeds"`
-	Private     bool     `yaml:"private"`
-	PieceLength uint     `yaml:"piece_length"`
-	Comment     string   `yaml:"comment"`
-	Source      string   `yaml:"source"`
-	NoDate      bool     `yaml:"no_date"`
+	Output          string   `yaml:"output"`
+	Path            string   `yaml:"path"`
+	Name            string   `yaml:"-"`
+	Trackers        []string `yaml:"trackers"`
+	WebSeeds        []string `yaml:"webseeds"`
+	Private         bool     `yaml:"private"`
+	PieceLength     uint     `yaml:"piece_length"`
+	Comment         string   `yaml:"comment"`
+	Source          string   `yaml:"source"`
+	NoDate          bool     `yaml:"no_date"`
+	ExcludePatterns []string `yaml:"exclude_patterns"`
 }
 
 // ToCreateOptions converts a BatchJob to CreateTorrentOptions
@@ -38,17 +39,18 @@ func (j *BatchJob) ToCreateOptions(verbose bool, quiet bool, version string) Cre
 	}
 
 	opts := CreateTorrentOptions{
-		Path:       j.Path,
-		Name:       j.Name,
-		TrackerURL: tracker,
-		WebSeeds:   j.WebSeeds,
-		IsPrivate:  j.Private,
-		Comment:    j.Comment,
-		Source:     j.Source,
-		NoDate:     j.NoDate,
-		Verbose:    verbose,
-		Quiet:      quiet,
-		Version:    version,
+		Path:            j.Path,
+		Name:            j.Name,
+		TrackerURL:      tracker,
+		WebSeeds:        j.WebSeeds,
+		IsPrivate:       j.Private,
+		Comment:         j.Comment,
+		Source:          j.Source,
+		NoDate:          j.NoDate,
+		Verbose:         verbose,
+		Quiet:           quiet,
+		Version:         version,
+		ExcludePatterns: j.ExcludePatterns,
 	}
 
 	if j.PieceLength != 0 {

--- a/internal/torrent/create.go
+++ b/internal/torrent/create.go
@@ -170,7 +170,7 @@ func CreateTorrent(opts CreateTorrentOptions) (*Torrent, error) {
 			}
 			return nil
 		}
-		if shouldIgnoreFile(filePath) {
+		if shouldIgnoreFile(filePath, opts.ExcludePatterns) {
 			return nil
 		}
 		files = append(files, fileEntry{

--- a/internal/torrent/ignore.go
+++ b/internal/torrent/ignore.go
@@ -1,6 +1,9 @@
 package torrent
 
-import "strings"
+import (
+	"path/filepath"
+	"strings"
+)
 
 // file patterns to ignore in source directory (case insensitive)
 var ignoredPatterns = []string{
@@ -11,12 +14,36 @@ var ignoredPatterns = []string{
 }
 
 // shouldIgnoreFile checks if a file should be ignored based on predefined patterns
-func shouldIgnoreFile(path string) bool {
+// and user-defined exclude patterns (glob matching).
+func shouldIgnoreFile(path string, excludePatterns []string) bool {
+	// first check built-in patterns (exact suffix match, case insensitive)
 	lowerPath := strings.ToLower(path)
 	for _, pattern := range ignoredPatterns {
 		if strings.HasSuffix(lowerPath, pattern) {
 			return true
 		}
 	}
+
+	// then check user-defined exclude patterns (glob matching on filename, case insensitive)
+	if len(excludePatterns) > 0 {
+		filename := filepath.Base(path)
+		lowerFilename := strings.ToLower(filename)
+
+		for _, patternGroup := range excludePatterns {
+			for _, pattern := range strings.Split(patternGroup, ",") {
+				pattern = strings.TrimSpace(pattern)
+				if pattern == "" {
+					continue
+				}
+
+				match, err := filepath.Match(strings.ToLower(pattern), lowerFilename)
+				// we ignore the error from filepath.Match as malformed patterns simply won't match
+				if err == nil && match {
+					return true
+				}
+			}
+		}
+	}
+
 	return false
 }

--- a/internal/torrent/types.go
+++ b/internal/torrent/types.go
@@ -8,22 +8,23 @@ import (
 
 // CreateTorrentOptions contains all options for creating a torrent
 type CreateTorrentOptions struct {
-	Path           string
-	Name           string
-	TrackerURL     string
-	WebSeeds       []string
-	IsPrivate      bool
-	Comment        string
-	PieceLengthExp *uint
-	MaxPieceLength *uint
-	Source         string
-	NoDate         bool
-	NoCreator      bool
-	Verbose        bool
-	Version        string
-	OutputPath     string
-	Entropy        bool
-	Quiet          bool
+	Path            string
+	Name            string
+	TrackerURL      string
+	WebSeeds        []string
+	IsPrivate       bool
+	Comment         string
+	PieceLengthExp  *uint
+	MaxPieceLength  *uint
+	Source          string
+	NoDate          bool
+	NoCreator       bool
+	Verbose         bool
+	Version         string
+	OutputPath      string
+	Entropy         bool
+	Quiet           bool
+	ExcludePatterns []string
 }
 
 // Torrent represents a torrent file with additional functionality

--- a/schema/batch.json
+++ b/schema/batch.json
@@ -64,9 +64,16 @@
             "type": "boolean",
             "description": "Don't write creation date",
             "default": false
+          },
+          "exclude_patterns": {
+            "type": "array",
+            "description": "List of glob patterns to exclude files (e.g., \"*.nfo\", \"*sample*\")",
+            "items": {
+              "type": "string"
+            }
           }
         }
       }
     }
   }
-} 
+}

--- a/schema/presets.json
+++ b/schema/presets.json
@@ -51,6 +51,13 @@
         "no_date": {
           "type": "boolean",
           "description": "Don't write creation date"
+        },
+        "exclude_patterns": {
+          "type": "array",
+          "description": "List of glob patterns to exclude files (e.g., \"*.nfo\", \"*sample*\")",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -104,9 +111,16 @@
             "description": "Maximum piece length as 2^n bytes (16-27)",
             "minimum": 16,
             "maximum": 27
+          },
+          "exclude_patterns": {
+            "type": "array",
+            "description": "List of glob patterns to exclude files (e.g., \"*.nfo\", \"*sample*\")",
+            "items": {
+              "type": "string"
+            }
           }
         }
       }
     }
   }
-} 
+}


### PR DESCRIPTION
Added file exclusion functionality. Users can now specify file patterns to exclude during torrent creation using the  `--exclude` flag, and the `exclude_patterns` field in batch configuration and preset definitions. The implementation uses case-insensitive glob pattern matching. 