### PR TITLE
refactor(cmd): improve version logic

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -13,38 +11,10 @@ const banner = `         __   ___.
 |__|_|  /__|_ \|___  /__|   |__|   
       \/     \/    \/              `
 
-var (
-	version   string
-	buildTime string
-)
-
 var rootCmd = &cobra.Command{
 	Use:   "mkbrr",
 	Short: "A tool to inspect and create torrent files",
 	Long:  banner + "\n\nmkbrr is a tool to create and inspect torrent files.",
-}
-
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Print version information",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("Version: %s\n", version)
-		fmt.Printf("Build Time: %s\n", buildTime)
-	},
-	DisableFlagsInUseLine: true,
-}
-
-func SetVersion(v, bt string) {
-	version = v
-	buildTime = bt
-}
-
-func init() {
-	versionCmd.SetUsageTemplate(`Usage:
-  {{.CommandPath}}
-
-Prints the version and build time information for mkbrr.
-`)
 }
 
 func Execute() error {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -27,12 +27,6 @@ Flags:
 }
 
 func runUpdate(cmd *cobra.Command, args []string) error {
-
-	if version == "dev" {
-		fmt.Println("Update is not supported on development builds")
-		return nil
-	}
-
 	v, err := semver.ParseTolerant(version)
 	if err != nil {
 		return fmt.Errorf("could not parse version: %w", err)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"runtime/debug"
 
 	"github.com/spf13/cobra"
 )
@@ -24,6 +25,11 @@ var versionCmd = &cobra.Command{
 }
 
 func SetVersion(v, bt string) {
+	if v == "dev" {
+		if info, ok := debug.ReadBuildInfo(); ok {
+			v = info.Main.Version
+		}
+	}
 	version = v
 	buildTime = bt
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	version   string
+	buildTime string
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version information",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("mkbrr version: %s\n", version)
+		if buildTime != "unknown" {
+			fmt.Printf("Build Time:    %s\n", buildTime)
+		}
+	},
+	DisableFlagsInUseLine: true,
+}
+
+func SetVersion(v, bt string) {
+	version = v
+	buildTime = bt
+}
+
+func init() {
+	versionCmd.SetUsageTemplate(`Usage:
+  {{.CommandPath}}
+
+Prints the version and build time information for mkbrr.
+`)
+}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"runtime/debug"
 
 	"github.com/autobrr/mkbrr/cmd"
 )
@@ -12,6 +13,12 @@ var (
 )
 
 func main() {
+	if version == "dev" {
+		if info, ok := debug.ReadBuildInfo(); ok {
+			version = info.Main.Version
+		}
+	}
+
 	cmd.SetVersion(version, buildTime)
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"os"
-	"runtime/debug"
 
 	"github.com/autobrr/mkbrr/cmd"
 )
@@ -13,12 +12,6 @@ var (
 )
 
 func main() {
-	if version == "dev" {
-		if info, ok := debug.ReadBuildInfo(); ok {
-			version = info.Main.Version
-		}
-	}
-
 	cmd.SetVersion(version, buildTime)
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
Moved version logic from root.go to a new version.go.

Using `debug.ReadBuildInfo` to get version for binaries installed with `go install github.com/autobrr/mkbrr@latest`. Needed for `mkbrr update` to work for these installs.