### PR TITLE
fix: correct multi-episode season pack detection

### DIFF
--- a/internal/torrent/display.go
+++ b/internal/torrent/display.go
@@ -118,8 +118,8 @@ func (d *Display) SetBatch(isBatch bool) {
 }
 
 var (
-	magenta    = color.New(color.FgMagenta).SprintFunc()
-	green      = color.New(color.FgGreen).SprintFunc()
+	magenta = color.New(color.FgMagenta).SprintFunc()
+	//green      = color.New(color.FgGreen).SprintFunc()
 	yellow     = color.New(color.FgYellow).SprintFunc()
 	success    = color.New(color.FgGreen).SprintFunc()
 	label      = color.New(color.FgCyan).SprintFunc()
@@ -291,11 +291,19 @@ func (d *Display) ShowSeasonPackWarnings(info *SeasonPackInfo) {
 		return
 	}
 
-	if info.IsSuspicious || len(info.MissingEpisodes) > 0 {
+	// Only show warning if we have missing episodes
+	if len(info.MissingEpisodes) > 0 {
 		fmt.Fprintf(d.output, "\n%s %s\n", yellow("Warning:"), "Possible incomplete season pack detected")
 		fmt.Fprintf(d.output, "  %-13s %d\n", label("Season number:"), info.Season)
 		fmt.Fprintf(d.output, "  %-13s %d\n", label("Highest episode number found:"), info.MaxEpisode)
-		fmt.Fprintf(d.output, "  %-13s %d\n", label("Video files:"), info.VideoFileCount)
+		fmt.Fprintf(d.output, "  %-13s %d\n", label("Episodes found:"), len(info.Episodes)) // Use episode count
+
+		// Format missing episodes list
+		missingStrs := make([]string, len(info.MissingEpisodes))
+		for i, ep := range info.MissingEpisodes {
+			missingStrs[i] = fmt.Sprintf("episode %d", ep)
+		}
+		fmt.Fprintf(d.output, "  %-13s %s\n", label("Missing:"), strings.Join(missingStrs, ", "))
 
 		fmt.Fprintln(d.output, yellow("\nThis may be an incomplete season pack. Check files before uploading."))
 	}

--- a/internal/torrent/display.go
+++ b/internal/torrent/display.go
@@ -291,14 +291,12 @@ func (d *Display) ShowSeasonPackWarnings(info *SeasonPackInfo) {
 		return
 	}
 
-	// Only show warning if we have missing episodes
 	if len(info.MissingEpisodes) > 0 {
 		fmt.Fprintf(d.output, "\n%s %s\n", yellow("Warning:"), "Possible incomplete season pack detected")
 		fmt.Fprintf(d.output, "  %-13s %d\n", label("Season number:"), info.Season)
 		fmt.Fprintf(d.output, "  %-13s %d\n", label("Highest episode number found:"), info.MaxEpisode)
-		fmt.Fprintf(d.output, "  %-13s %d\n", label("Episodes found:"), len(info.Episodes)) // Use episode count
+		fmt.Fprintf(d.output, "  %-13s %d\n", label("Episodes found:"), len(info.Episodes))
 
-		// Format missing episodes list
 		missingStrs := make([]string, len(info.MissingEpisodes))
 		for i, ep := range info.MissingEpisodes {
 			missingStrs[i] = fmt.Sprintf("episode %d", ep)

--- a/internal/torrent/seasonfinder.go
+++ b/internal/torrent/seasonfinder.go
@@ -71,7 +71,7 @@ func AnalyzeSeasonPack(files []fileEntry) *SeasonPackInfo {
 		if videoExtensions[ext] {
 			info.VideoFileCount++
 
-			// Check for multi-episodes first
+			// check for multi-episodes first
 			multiEps := extractMultiEpisodes(filepath.Base(file.path))
 			if len(multiEps) > 0 {
 				for _, ep := range multiEps {
@@ -83,7 +83,6 @@ func AnalyzeSeasonPack(files []fileEntry) *SeasonPackInfo {
 					}
 				}
 			} else {
-				// Fall back to single episode check if no multi-episodes found
 				_, episode := extractSeasonEpisode(filepath.Base(file.path))
 				if episode > 0 {
 					episodeMap[episode] = true

--- a/internal/torrent/seasonfinder.go
+++ b/internal/torrent/seasonfinder.go
@@ -31,7 +31,7 @@ var seasonPackPatterns = []*regexp.Regexp{
 }
 
 var episodePattern = regexp.MustCompile(`(?i)S\d{1,2}E(\d{1,3})`)
-var multiEpisodePattern = regexp.MustCompile(`(?i)S\d{1,2}E(\d{1,3})-?E?(\d{1,3})`)
+var multiEpisodePattern = regexp.MustCompile(`(?i)S\d{1,2}E(\d{1,3})(?:-E?|E)(\d{1,3})`)
 
 var videoExtensions = map[string]bool{
 	".mkv": true,
@@ -71,20 +71,24 @@ func AnalyzeSeasonPack(files []fileEntry) *SeasonPackInfo {
 		if videoExtensions[ext] {
 			info.VideoFileCount++
 
-			_, episode := extractSeasonEpisode(filepath.Base(file.path))
-			if episode > 0 {
-				episodeMap[episode] = true
-				if episode > info.MaxEpisode {
-					info.MaxEpisode = episode
-				}
-			}
-
+			// Check for multi-episodes first
 			multiEps := extractMultiEpisodes(filepath.Base(file.path))
-			for _, ep := range multiEps {
-				if ep > 0 {
-					episodeMap[ep] = true
-					if ep > info.MaxEpisode {
-						info.MaxEpisode = ep
+			if len(multiEps) > 0 {
+				for _, ep := range multiEps {
+					if ep > 0 {
+						episodeMap[ep] = true
+						if ep > info.MaxEpisode {
+							info.MaxEpisode = ep
+						}
+					}
+				}
+			} else {
+				// Fall back to single episode check if no multi-episodes found
+				_, episode := extractSeasonEpisode(filepath.Base(file.path))
+				if episode > 0 {
+					episodeMap[episode] = true
+					if episode > info.MaxEpisode {
+						info.MaxEpisode = episode
 					}
 				}
 			}
@@ -154,6 +158,7 @@ func extractMultiEpisodes(filename string) []int {
 	episodes := []int{}
 
 	matches := multiEpisodePattern.FindStringSubmatch(filename)
+
 	if len(matches) > 2 {
 		start, err1 := strconv.Atoi(matches[1])
 		end, err2 := strconv.Atoi(matches[2])

--- a/internal/torrent/seasonfinder_test.go
+++ b/internal/torrent/seasonfinder_test.go
@@ -26,6 +26,55 @@ func TestDetectSeasonNumber(t *testing.T) {
 	}
 }
 
+func TestAnalyzeSeasonPack_MultiEpisode(t *testing.T) {
+	files := []fileEntry{
+		{path: filepath.Join("/test", "Show.S02E01E02.mkv")},
+		{path: filepath.Join("/test", "Show.S02E03.mkv")},
+		{path: filepath.Join("/test", "Show.S02E04.mkv")},
+		{path: filepath.Join("/test", "Show.S02E05.mkv")},
+		{path: filepath.Join("/test", "Show.S02E06.mkv")},
+		{path: filepath.Join("/test", "Show.S02E07.mkv")},
+		{path: filepath.Join("/test", "Show.S02E08.mkv")},
+		{path: filepath.Join("/test", "Show.S02E09.mkv")},
+		{path: filepath.Join("/test", "Show.S02E10E11.mkv")},
+		{path: filepath.Join("/test", "Show.S02E12.mkv")},
+	}
+
+	info := AnalyzeSeasonPack(files)
+
+	if !info.IsSeasonPack {
+		t.Error("Expected IsSeasonPack to be true")
+	}
+	if info.Season != 2 {
+		t.Errorf("Expected Season 2, got %d", info.Season)
+	}
+	if info.VideoFileCount != 10 {
+		t.Errorf("Expected 10 video files, got %d", info.VideoFileCount)
+	}
+	if info.MaxEpisode != 12 {
+		t.Errorf("Expected MaxEpisode 12, got %d", info.MaxEpisode)
+	}
+	if len(info.Episodes) != 12 {
+		t.Errorf("Expected 12 unique episodes, got %d", len(info.Episodes))
+	}
+	if len(info.MissingEpisodes) != 0 {
+		t.Errorf("Expected no missing episodes, got %v", info.MissingEpisodes)
+	}
+	if info.IsSuspicious {
+		t.Error("Expected IsSuspicious to be false for complete season pack with multi-episode file")
+	}
+
+	expectedEpisodes := make([]int, 12)
+	for i := range expectedEpisodes {
+		expectedEpisodes[i] = i + 1
+	}
+	for i, ep := range expectedEpisodes {
+		if i >= len(info.Episodes) || info.Episodes[i] != ep {
+			t.Errorf("Expected episode %d at position %d, got %d (or index out of bounds)", ep, i, info.Episodes[i])
+		}
+	}
+}
+
 func TestExtractSeasonEpisode(t *testing.T) {
 	tests := []struct {
 		filename      string


### PR DESCRIPTION
Fixes incorrect "incomplete season pack" warnings for packs containing multi-episode files.

Fixes #55 