### PR TITLE
fix(ignore): handle filepath.Match errors

### DIFF
--- a/internal/torrent/create.go
+++ b/internal/torrent/create.go
@@ -170,7 +170,11 @@ func CreateTorrent(opts CreateTorrentOptions) (*Torrent, error) {
 			}
 			return nil
 		}
-		if shouldIgnoreFile(filePath, opts.ExcludePatterns, opts.IncludePatterns) {
+		shouldIgnore, err := shouldIgnoreFile(filePath, opts.ExcludePatterns, opts.IncludePatterns)
+		if err != nil {
+			return fmt.Errorf("error processing file patterns: %w", err)
+		}
+		if shouldIgnore {
 			return nil
 		}
 		files = append(files, fileEntry{

--- a/internal/torrent/ignore.go
+++ b/internal/torrent/ignore.go
@@ -26,10 +26,6 @@ var ignoredPatterns = []string{
 //   - Check if the file matches any exclude pattern. If yes, IGNORE the file (return true).
 //
 // 4. If none of the above conditions cause the file to be ignored, KEEP the file (return false).
-//
-// Returns:
-//   - bool: true if the file should be ignored, false if it should be kept
-//   - error: if any pattern is malformed
 func shouldIgnoreFile(path string, excludePatterns []string, includePatterns []string) (bool, error) {
 	// 1. Check built-in patterns (always ignored)
 	lowerPath := strings.ToLower(path)

--- a/internal/torrent/ignore.go
+++ b/internal/torrent/ignore.go
@@ -1,6 +1,7 @@
 package torrent
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 )
@@ -25,12 +26,16 @@ var ignoredPatterns = []string{
 //   - Check if the file matches any exclude pattern. If yes, IGNORE the file (return true).
 //
 // 4. If none of the above conditions cause the file to be ignored, KEEP the file (return false).
-func shouldIgnoreFile(path string, excludePatterns []string, includePatterns []string) bool {
+//
+// Returns:
+//   - bool: true if the file should be ignored, false if it should be kept
+//   - error: if any pattern is malformed
+func shouldIgnoreFile(path string, excludePatterns []string, includePatterns []string) (bool, error) {
 	// 1. Check built-in patterns (always ignored)
 	lowerPath := strings.ToLower(path)
 	for _, pattern := range ignoredPatterns {
 		if strings.HasSuffix(lowerPath, pattern) {
-			return true
+			return true, nil
 		}
 	}
 
@@ -47,7 +52,10 @@ func shouldIgnoreFile(path string, excludePatterns []string, includePatterns []s
 					continue
 				}
 				match, err := filepath.Match(strings.ToLower(pattern), lowerFilename)
-				if err == nil && match {
+				if err != nil {
+					return false, fmt.Errorf("invalid include pattern %q: %w", pattern, err)
+				}
+				if match {
 					matchesInclude = true
 					break
 				}
@@ -58,9 +66,9 @@ func shouldIgnoreFile(path string, excludePatterns []string, includePatterns []s
 		}
 
 		if matchesInclude {
-			return false // Keep the file because it matches an include pattern
+			return false, nil // Keep the file because it matches an include pattern
 		} else {
-			return true // Ignore the file because include patterns were given, but none matched
+			return true, nil // Ignore the file because include patterns were given, but none matched
 		}
 	}
 
@@ -73,14 +81,16 @@ func shouldIgnoreFile(path string, excludePatterns []string, includePatterns []s
 					continue
 				}
 				match, err := filepath.Match(strings.ToLower(pattern), lowerFilename)
-				// we ignore the error from filepath.Match as malformed patterns simply won't match
-				if err == nil && match {
-					return true // Ignore if it matches an exclude pattern (and no include patterns were specified)
+				if err != nil {
+					return false, fmt.Errorf("invalid exclude pattern %q: %w", pattern, err)
+				}
+				if match {
+					return true, nil // Ignore if it matches an exclude pattern (and no include patterns were specified)
 				}
 			}
 		}
 	}
 
 	// 4. Keep the file if no ignore conditions were met
-	return false
+	return false, nil
 }


### PR DESCRIPTION
Previously, malformed include/exclude patterns were silently ignored in `ignore.go`. Now properly handle and report these errors.