### PR TITLE
fix(create): recalculate file offsets after sorting

### DIFF
--- a/internal/torrent/create.go
+++ b/internal/torrent/create.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/anacrolix/torrent/bencode"
 	"github.com/anacrolix/torrent/metainfo"
+
 	"github.com/autobrr/mkbrr/internal/preset"
 	"github.com/autobrr/mkbrr/internal/trackers"
 )
@@ -193,6 +194,14 @@ func CreateTorrent(opts CreateTorrentOptions) (*Torrent, error) {
 	sort.Slice(files, func(i, j int) bool {
 		return files[i].path < files[j].path
 	})
+
+	// Recalculate offsets based on the sorted file order
+	// Context: https://github.com/autobrr/mkbrr/issues/64
+	var currentOffset int64 = 0
+	for i := range files {
+		files[i].offset = currentOffset
+		currentOffset += files[i].length
+	}
 
 	// Function to create torrent with given piece length
 	createWithPieceLength := func(pieceLength uint) (*Torrent, error) {

--- a/internal/torrent/hasher.go
+++ b/internal/torrent/hasher.go
@@ -274,11 +274,6 @@ func (h *pieceHasher) hashPieceRange(startPiece, endPiece int, completedPieces *
 				reader.position = readStart
 			}
 
-			// sync file state before reading, potentially helping with cache consistency
-			if err := reader.file.Sync(); err != nil {
-				return fmt.Errorf("failed to sync file %s before reading: %w", file.path, err)
-			}
-
 			// read file data in chunks to avoid large memory allocations
 			remaining := readLength
 			for remaining > 0 {

--- a/internal/torrent/hasher.go
+++ b/internal/torrent/hasher.go
@@ -274,6 +274,11 @@ func (h *pieceHasher) hashPieceRange(startPiece, endPiece int, completedPieces *
 				reader.position = readStart
 			}
 
+			// sync file state before reading, potentially helping with cache consistency
+			if err := reader.file.Sync(); err != nil {
+				return fmt.Errorf("failed to sync file %s before reading: %w", file.path, err)
+			}
+
 			// read file data in chunks to avoid large memory allocations
 			remaining := readLength
 			for remaining > 0 {


### PR DESCRIPTION
Fixes a bug where file offsets were calculated based on the directory walk order but used after the file list was sorted alphabetically. This led to incorrect offsets being passed to the hasher, causing hash mismatches, particularly in torrents with many files (e.g., BDMV structures).

This change recalculates the offsets correctly after the file list is sorted, ensuring the hasher reads the correct data segments.