### PR TITLE
fix(create): handle symlinks during creation

### DIFF
--- a/internal/torrent/create.go
+++ b/internal/torrent/create.go
@@ -160,30 +160,79 @@ func CreateTorrent(opts CreateTorrentOptions) (*Torrent, error) {
 	files := make([]fileEntry, 0, 1)
 	var totalSize int64
 	var baseDir string
+	originalPaths := make(map[string]string) // Map resolved path -> original path for metainfo
 
-	err := filepath.Walk(path, func(filePath string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if info.IsDir() {
-			if baseDir == "" {
-				baseDir = filePath
+	err := filepath.Walk(path, func(currentPath string, walkInfo os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			// Check if the error is due to a broken symlink during walk
+			// If Lstat works but Stat fails, it's likely a broken link we might handle later
+			if _, lerr := os.Lstat(currentPath); lerr == nil {
+				// We can Lstat it, maybe it's a broken link we can ignore?
+				// For now, let's return the original error to maintain behavior.
+				// Consider adding verbose logging here if needed.
 			}
-			return nil
+			return walkErr // Return original error from Walk
 		}
-		shouldIgnore, err := shouldIgnoreFile(filePath, opts.ExcludePatterns, opts.IncludePatterns)
+
+		// Use Lstat to get info about the entry itself (link or file/dir)
+		lstatInfo, err := os.Lstat(currentPath)
 		if err != nil {
-			return fmt.Errorf("error processing file patterns: %w", err)
+			// If Lstat fails, we can't proceed with this entry
+			fmt.Fprintf(os.Stderr, "Warning: could not lstat %q: %v\n", currentPath, err)
+			return nil // Skip this entry
+		}
+
+		resolvedPath := currentPath
+		resolvedInfo := lstatInfo
+
+		// Check if it's a symlink
+		if lstatInfo.Mode()&os.ModeSymlink != 0 {
+			linkTarget, err := os.Readlink(currentPath)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: could not readlink %q: %v\n", currentPath, err)
+				return nil // Skip broken link
+			}
+			// If link is relative, resolve it based on the link's directory
+			if !filepath.IsAbs(linkTarget) {
+				linkTarget = filepath.Join(filepath.Dir(currentPath), linkTarget)
+			}
+			resolvedPath = filepath.Clean(linkTarget)
+
+			// Stat the target of the link
+			statInfo, err := os.Stat(resolvedPath)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: could not stat symlink target %q for link %q: %v\n", resolvedPath, currentPath, err)
+				return nil // Skip broken link or inaccessible target
+			}
+			resolvedInfo = statInfo // Use the target's info
+		}
+
+		// Now, use resolvedInfo for checks and processing
+		if resolvedInfo.IsDir() {
+			// If it's a directory (or a link pointing to one), set baseDir if needed and continue walk
+			if baseDir == "" && currentPath == path { // Only set baseDir for the initial path if it's a dir
+				baseDir = currentPath
+			}
+			return nil // Continue walking
+		}
+
+		// It's a file (or a link pointing to one)
+		shouldIgnore, err := shouldIgnoreFile(currentPath, opts.ExcludePatterns, opts.IncludePatterns) // Ignore based on original path
+		if err != nil {
+			return fmt.Errorf("error processing file patterns for %q: %w", currentPath, err)
 		}
 		if shouldIgnore {
 			return nil
 		}
+
+		// Add the file using the resolved path for hashing, but store the original path for metainfo
 		files = append(files, fileEntry{
-			path:   filePath,
-			length: info.Size(),
+			path:   resolvedPath, // Use the actual content path for hashing
+			length: resolvedInfo.Size(),
 			offset: totalSize,
 		})
-		totalSize += info.Size()
+		originalPaths[resolvedPath] = currentPath // Store mapping for metainfo generation
+		totalSize += resolvedInfo.Size()
 		return nil
 	})
 	if err != nil {
@@ -250,11 +299,16 @@ func CreateTorrent(opts CreateTorrentOptions) (*Torrent, error) {
 			if pathInfo.IsDir() {
 				// if it's a directory, use the folder structure even for single files
 				info.Files = make([]metainfo.FileInfo, 1)
-				relPath, _ := filepath.Rel(baseDir, files[0].path)
-				pathComponents := strings.Split(relPath, string(filepath.Separator))
+				// Use the original path for calculating relative path in metainfo
+				originalFilepath := originalPaths[files[0].path]
+				if originalFilepath == "" {
+					originalFilepath = files[0].path // Fallback if mapping missing
+				}
+				relPath, _ := filepath.Rel(baseDir, originalFilepath)
+				pathComponents := strings.Split(filepath.ToSlash(relPath), "/") // Ensure forward slashes
 				info.Files[0] = metainfo.FileInfo{
 					Path:   pathComponents,
-					Length: files[0].length,
+					Length: files[0].length, // Length comes from resolved file
 				}
 			} else {
 				// if it's a single file directly, use the simple format
@@ -263,11 +317,16 @@ func CreateTorrent(opts CreateTorrentOptions) (*Torrent, error) {
 		} else {
 			info.Files = make([]metainfo.FileInfo, len(files))
 			for i, f := range files {
-				relPath, _ := filepath.Rel(baseDir, f.path)
-				pathComponents := strings.Split(relPath, string(filepath.Separator))
+				// Use the original path for calculating relative path in metainfo
+				originalFilepath := originalPaths[f.path]
+				if originalFilepath == "" {
+					originalFilepath = f.path // Fallback if mapping missing
+				}
+				relPath, _ := filepath.Rel(baseDir, originalFilepath)
+				pathComponents := strings.Split(filepath.ToSlash(relPath), "/") // Ensure forward slashes
 				info.Files[i] = metainfo.FileInfo{
 					Path:   pathComponents,
-					Length: f.length,
+					Length: f.length, // Length comes from resolved file
 				}
 			}
 		}


### PR DESCRIPTION
Fixes the issue where `mkbrr` would attempt to create a torrent directly from a symbolic link path instead of resolving the link and using the target content.

Closes #63 