### PR TITLE
feat(create): add --output-dir flag

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -21,6 +21,7 @@ type createOptions struct {
 	trackerURL        string
 	comment           string
 	outputPath        string
+	outputDir         string
 	source            string
 	batchFile         string
 	presetName        string
@@ -28,6 +29,7 @@ type createOptions struct {
 	webSeeds          []string
 	excludePatterns   []string
 	includePatterns   []string
+	createWorkers     int
 	isPrivate         bool
 	noDate            bool
 	noCreator         bool
@@ -35,7 +37,6 @@ type createOptions struct {
 	entropy           bool
 	quiet             bool
 	skipPrefix        bool
-	createWorkers     int
 }
 
 var options = createOptions{
@@ -95,6 +96,7 @@ func init() {
 	}
 
 	createCmd.Flags().StringVarP(&options.outputPath, "output", "o", "", "set output path (default: <name>.torrent)")
+	createCmd.Flags().StringVar(&options.outputDir, "output-dir", "", "output directory for created torrent")
 	createCmd.Flags().StringVarP(&options.source, "source", "s", "", "add source string")
 	createCmd.Flags().BoolVarP(&options.noDate, "no-date", "d", false, "don't write creation date")
 	createCmd.Flags().BoolVarP(&options.noCreator, "no-creator", "", false, "don't write creator")
@@ -181,6 +183,7 @@ func buildCreateOptions(cmd *cobra.Command, inputPath string, opts createOptions
 		ExcludePatterns: opts.excludePatterns,
 		IncludePatterns: opts.includePatterns,
 		Workers:         opts.createWorkers,
+		OutputDir:       opts.outputDir,
 	}
 
 	// If a preset is specified, load the preset options and merge with command-line flags

--- a/internal/torrent/create.go
+++ b/internal/torrent/create.go
@@ -460,14 +460,23 @@ func Create(opts CreateTorrentOptions) (*TorrentInfo, error) {
 		opts.Name = filepath.Base(filepath.Clean(opts.Path))
 	}
 
-	if opts.OutputPath == "" {
-		fileName := opts.Name
-		if opts.TrackerURL != "" && !opts.SkipPrefix {
-			fileName = preset.GetDomainPrefix(opts.TrackerURL) + "_" + opts.Name
-		}
+	fileName := opts.Name
+	if opts.TrackerURL != "" && !opts.SkipPrefix {
+		fileName = preset.GetDomainPrefix(opts.TrackerURL) + "_" + opts.Name
+	}
+
+	if opts.OutputDir != "" {
+		opts.OutputPath = filepath.Join(opts.OutputDir, fileName+".torrent")
+	} else if opts.OutputPath == "" {
 		opts.OutputPath = fileName + ".torrent"
 	} else if !strings.HasSuffix(opts.OutputPath, ".torrent") {
 		opts.OutputPath = opts.OutputPath + ".torrent"
+	}
+
+	if opts.OutputDir != "" {
+		if err := os.MkdirAll(opts.OutputDir, 0755); err != nil {
+			return nil, fmt.Errorf("error creating output directory %q: %w", opts.OutputDir, err)
+		}
 	}
 
 	// create torrent

--- a/internal/torrent/types.go
+++ b/internal/torrent/types.go
@@ -17,9 +17,11 @@ type CreateTorrentOptions struct {
 	Source          string
 	Version         string
 	OutputPath      string
+	OutputDir       string
 	WebSeeds        []string
 	ExcludePatterns []string
 	IncludePatterns []string
+	Workers         int
 	IsPrivate       bool
 	NoDate          bool
 	NoCreator       bool
@@ -27,7 +29,6 @@ type CreateTorrentOptions struct {
 	Entropy         bool
 	Quiet           bool
 	SkipPrefix      bool
-	Workers         int
 }
 
 // Torrent represents a torrent file with additional functionality

--- a/internal/trackers/trackers.go
+++ b/internal/trackers/trackers.go
@@ -4,12 +4,12 @@ import "strings"
 
 // TrackerConfig holds tracker-specific configuration
 type TrackerConfig struct {
+	DefaultSource    string           // default source to use for this tracker
 	URLs             []string         // list of tracker URLs that share this config
 	PieceSizeRanges  []PieceSizeRange // custom piece size ranges for specific content sizes
 	MaxPieceLength   uint             // maximum piece length exponent (2^n)
 	MaxTorrentSize   uint64           // maximum .torrent file size in bytes (0 means no limit)
 	UseDefaultRanges bool             // whether to use default piece size ranges when content size is outside custom ranges
-	DefaultSource    string           // default source to use for this tracker
 }
 
 // PieceSizeRange defines a range of content sizes and their corresponding piece size exponent


### PR DESCRIPTION
Adds the `--output-dir` flag to the `create` command, allowing users to specify a target directory for the generated torrent file without using `--output` which requires a file name.

This brings the `create` command's output handling closer to the `modify` command's behavior.

This is also likely useful for #85 