### PR TITLE
feat(modify): use metadata title for output name

### DIFF
--- a/internal/torrent/modify.go
+++ b/internal/torrent/modify.go
@@ -192,8 +192,13 @@ func ModifyTorrent(path string, opts Options) (*Result, error) {
 		metaInfoName = info.Name
 	}
 
+	basePath := path
+	if opts.OutputPattern == "" && metaInfoName != "" {
+		basePath = metaInfoName + ".torrent"
+	}
+
 	// generate output path using the preset generating helper
-	outPath := preset.GenerateOutputPath(path, opts.OutputDir, opts.PresetName, opts.OutputPattern, opts.TrackerURL, metaInfoName, opts.SkipPrefix)
+	outPath := preset.GenerateOutputPath(basePath, opts.OutputDir, opts.PresetName, opts.OutputPattern, opts.TrackerURL, metaInfoName, opts.SkipPrefix)
 	result.OutputPath = outPath
 
 	// ensure output directory exists if specified


### PR DESCRIPTION
When modifying a torrent file using the `modify` command, if no specific output filename pattern is provided via `--output`, the default filename for the modified torrent is now derived from the torrent's metadata title (info.name) instead of the original input torrent filename. If the metadata title is empty, it falls back to using the original filename.