### PR TITLE
fix: multiple trackers cannot be added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-<h1 align="center">⚡ mkbrr</h1> 
-<p align="center"> 
-  <strong>Simple. Smart. Fast.</strong><br> 
+<h1 align="center">⚡ mkbrr</h1>
+<p align="center">
+  <strong>Simple. Smart. Fast.</strong><br>
   A powerful CLI tool to create, inspect, and modify torrent files. Private by default. Tracker aware.
 </p>
 <div align="center">
-<p align="center"> 
+<p align="center">
   <img src="https://img.shields.io/badge/Go-1.24-blue?logo=go" alt="Go version">
   <img src="https://img.shields.io/badge/build-passing-brightgreen" alt="Build Status">
   <img src="https://img.shields.io/github/v/release/autobrr/mkbrr" alt="Latest Release">
@@ -234,6 +234,9 @@ mkbrr modify *.torrent --private=false
 
 # See what would be changed without making actual changes
 mkbrr modify original.torrent --tracker https://new-tracker.com --dry-run
+
+# Modifying the torrent to contain multiple trackers
+mkbrr modify original.torrent -t https://first.com -t https://second.com -t https://third.com
 
 # Randomize info hash
 mkbrr modify original.torrent -e

--- a/cmd/modify.go
+++ b/cmd/modify.go
@@ -15,7 +15,7 @@ type modifyOptions struct {
 	PresetFile string
 	OutputDir  string
 	Output     string
-	Tracker    string
+	Trackers   []string
 	Comment    string
 	Source     string
 	WebSeeds   []string
@@ -56,7 +56,7 @@ func init() {
 	modifyCmd.Flags().StringVarP(&modifyOpts.Output, "output", "o", "", "custom output filename (without extension)")
 	modifyCmd.Flags().BoolVarP(&modifyOpts.NoDate, "no-date", "d", false, "don't update creation date")
 	modifyCmd.Flags().BoolVarP(&modifyOpts.NoCreator, "no-creator", "", false, "don't write creator")
-	modifyCmd.Flags().StringVarP(&modifyOpts.Tracker, "tracker", "t", "", "tracker URL")
+	modifyCmd.Flags().StringArrayVarP(&modifyOpts.Trackers, "tracker", "t", nil, "tracker URLs (can be specified multiple times)")
 	modifyCmd.Flags().StringArrayVarP(&modifyOpts.WebSeeds, "web-seed", "w", nil, "add web seed URLs")
 	modifyCmd.Flags().BoolVarP(&modifyOpts.Private, "private", "p", true, "make torrent private (default: true)")
 	modifyCmd.Flags().StringVarP(&modifyOpts.Comment, "comment", "c", "", "add comment")
@@ -87,7 +87,7 @@ func buildTorrentOptions(cmd *cobra.Command, opts modifyOptions) torrent.Options
 		DryRun:        opts.DryRun,
 		Verbose:       opts.Verbose,
 		Quiet:         opts.Quiet,
-		TrackerURL:    opts.Tracker,
+		TrackerURLs:   opts.Trackers,
 		WebSeeds:      opts.WebSeeds,
 		Comment:       opts.Comment,
 		Source:        opts.Source,

--- a/internal/torrent/modify.go
+++ b/internal/torrent/modify.go
@@ -208,7 +208,13 @@ func ModifyTorrent(path string, opts Options) (*Result, error) {
 	}
 
 	// generate output path using the preset generating helper
-	outPath := preset.GenerateOutputPath(basePath, outputDir, opts.PresetName, opts.OutputPattern, opts.TrackerURLs[0], metaInfoName, opts.SkipPrefix)
+	var trackerForOutput string
+	if len(opts.TrackerURLs) > 0 {
+		trackerForOutput = opts.TrackerURLs[0]
+	} else {
+		trackerForOutput = ""
+	}
+	outPath := preset.GenerateOutputPath(basePath, outputDir, opts.PresetName, opts.OutputPattern, trackerForOutput, metaInfoName, opts.SkipPrefix)
 	result.OutputPath = outPath
 
 	// ensure output directory exists if specified

--- a/internal/torrent/modify.go
+++ b/internal/torrent/modify.go
@@ -21,7 +21,7 @@ type Options struct {
 	PresetFile     string
 	OutputDir      string
 	OutputPattern  string
-	TrackerURL     string
+	TrackerURLs    []string
 	Comment        string
 	Source         string
 	Version        string
@@ -101,10 +101,14 @@ func ModifyTorrent(path string, opts Options) (*Result, error) {
 
 	// apply flag-based overrides:
 	// update tracker if flag provided
-	if opts.TrackerURL != "" {
-		mi.Announce = opts.TrackerURL
-		mi.AnnounceList = [][]string{{opts.TrackerURL}}
+	if len(opts.TrackerURLs) > 0 {
+		mi.Announce = opts.TrackerURLs[0] // Primary announce is the first one
+		announceList := make([][]string, 1)
+		announceList[0] = make([]string, len(opts.TrackerURLs))
+		copy(announceList[0], opts.TrackerURLs)
+		mi.AnnounceList = announceList
 		wasModified = true
+		// Note: This overrides any trackers set by a preset
 	}
 
 	// update web seeds if provided via flag
@@ -204,7 +208,7 @@ func ModifyTorrent(path string, opts Options) (*Result, error) {
 	}
 
 	// generate output path using the preset generating helper
-	outPath := preset.GenerateOutputPath(basePath, outputDir, opts.PresetName, opts.OutputPattern, opts.TrackerURL, metaInfoName, opts.SkipPrefix)
+	outPath := preset.GenerateOutputPath(basePath, outputDir, opts.PresetName, opts.OutputPattern, opts.TrackerURLs[0], metaInfoName, opts.SkipPrefix)
 	result.OutputPath = outPath
 
 	// ensure output directory exists if specified


### PR DESCRIPTION
#### What is the relevant ticket?
* In response to an issue #92 that I discovered yesterday

#### What’s this PR do?
##### Add
* None
##### Change
* Multiple `-t` can be specified to add multiple trackers
##### Remove
* None

#### Where should the reviewer start?
* `cmd/modify.go` to support multiple trackers
* `internal/torrent/modify.go` to support multiple trackers

#### How should this be manually tested?
1. `go run main.go inspect original.torrent`
2. `go run main.go modify original.torrent -t https://first.com -t https://second.com -t https://third.com`
3. `go run main.go inspect first_modified.torrent`

#### Risk involved?
* Yes

#### Screenshots (if appropriate):
* N/A

#### Does the documentation or dependencies need an update?
* Updated in 2e2a622f5a75a45cadaa750b232e5e722ba35fe8
