### PR TITLE
fix: accurate duration display without rounding

### DIFF
--- a/internal/torrent/display.go
+++ b/internal/torrent/display.go
@@ -236,17 +236,10 @@ func (d *Display) ShowOutputPathWithTime(path string, duration time.Duration) {
 	if !d.formatter.verbose {
 		fmt.Fprintln(d.output)
 	}
-	if duration < time.Second {
-		fmt.Fprintf(d.output, "%s %s (%s)\n",
-			success("Wrote"),
-			white(path),
-			magenta(fmt.Sprintf("elapsed %dms", duration.Milliseconds())))
-	} else {
-		fmt.Fprintf(d.output, "%s %s (%s)\n",
-			success("Wrote"),
-			white(path),
-			magenta(fmt.Sprintf("elapsed %.2fs", duration.Seconds())))
-	}
+	fmt.Fprintf(d.output, "%s %s (%s)\n",
+		success("Wrote"),
+		white(path),
+		magenta(fmt.Sprintf("elapsed %s", d.formatter.FormatDuration(duration))))
 }
 
 func (d *Display) ShowBatchResults(results []BatchResult, duration time.Duration) {
@@ -308,10 +301,21 @@ func (f *Formatter) FormatBytes(bytes int64) string {
 }
 
 func (f *Formatter) FormatDuration(dur time.Duration) string {
-	if dur < time.Second {
+	switch {
+	case dur < time.Second:
 		return fmt.Sprintf("%dms", dur.Milliseconds())
+	case dur < time.Minute:
+		return fmt.Sprintf("%.1fs", dur.Seconds())
+	case dur < time.Hour:
+		minutes := int(dur.Minutes())
+		seconds := int(dur.Seconds()) % 60
+		return fmt.Sprintf("%dm %ds", minutes, seconds)
+	default:
+		hours := int(dur.Hours())
+		minutes := int(dur.Minutes()) % 60
+		seconds := int(dur.Seconds()) % 60
+		return fmt.Sprintf("%dh %dm %ds", hours, minutes, seconds)
 	}
-	return humanize.RelTime(time.Now().Add(-dur), time.Now(), "", "")
 }
 
 func (d *Display) ShowSeasonPackWarnings(info *SeasonPackInfo) {

--- a/internal/torrent/display_test.go
+++ b/internal/torrent/display_test.go
@@ -1,0 +1,111 @@
+package torrent
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFormatDuration(t *testing.T) {
+	formatter := NewFormatter(false)
+
+	tests := []struct {
+		name     string
+		duration time.Duration
+		expected string
+	}{
+		{
+			name:     "milliseconds",
+			duration: 500 * time.Millisecond,
+			expected: "500ms",
+		},
+		{
+			name:     "seconds only",
+			duration: 45 * time.Second,
+			expected: "45.0s",
+		},
+		{
+			name:     "minutes and seconds",
+			duration: 5*time.Minute + 30*time.Second,
+			expected: "5m 30s",
+		},
+		{
+			name:     "exactly one hour",
+			duration: 1 * time.Hour,
+			expected: "1h 0m 0s",
+		},
+		{
+			name:     "1 hour 44 minutes (user's reported case)",
+			duration: 1*time.Hour + 44*time.Minute,
+			expected: "1h 44m 0s",
+		},
+		{
+			name:     "1 hour 44 minutes with seconds",
+			duration: 1*time.Hour + 44*time.Minute + 12*time.Second,
+			expected: "1h 44m 12s",
+		},
+		{
+			name:     "2 hours 32 minutes",
+			duration: 2*time.Hour + 32*time.Minute,
+			expected: "2h 32m 0s",
+		},
+		{
+			name:     "hours minutes and seconds",
+			duration: 3*time.Hour + 15*time.Minute + 45*time.Second,
+			expected: "3h 15m 45s",
+		},
+		{
+			name:     "24 hours",
+			duration: 24 * time.Hour,
+			expected: "24h 0m 0s",
+		},
+		{
+			name:     "complex duration",
+			duration: 5*time.Hour + 59*time.Minute + 59*time.Second,
+			expected: "5h 59m 59s",
+		},
+		{
+			name:     "zero duration",
+			duration: 0,
+			expected: "0ms",
+		},
+		{
+			name:     "1 second exact",
+			duration: 1 * time.Second,
+			expected: "1.0s",
+		},
+		{
+			name:     "59 seconds",
+			duration: 59 * time.Second,
+			expected: "59.0s",
+		},
+		{
+			name:     "3.5 seconds",
+			duration: 3*time.Second + 500*time.Millisecond,
+			expected: "3.5s",
+		},
+		{
+			name:     "10.123 seconds (rounds to 1 decimal)",
+			duration: 10*time.Second + 123*time.Millisecond,
+			expected: "10.1s",
+		},
+		{
+			name:     "1 minute exact",
+			duration: 1 * time.Minute,
+			expected: "1m 0s",
+		},
+		{
+			name:     "59 minutes 59 seconds",
+			duration: 59*time.Minute + 59*time.Second,
+			expected: "59m 59s",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatter.FormatDuration(tt.duration)
+			if result != tt.expected {
+				t.Errorf("FormatDuration(%v) = %q, want %q", tt.duration, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Previously, durations like "1 hour 44 minutes" were rounded to "1 hour" due to humanize.RelTime() behavior. This fix implements a custom FormatDuration function that displays precise durations:

- Under 1 second: shows milliseconds (e.g., "500ms")
- Under 1 minute: shows seconds with 1 decimal (e.g., "3.5s")
- Under 1 hour: shows minutes and seconds (e.g., "5m 30s")
- 1 hour or more: shows hours, minutes, seconds (e.g., "1h 44m 0s")

Also updated ShowOutputPathWithTime to use the same formatting for consistency.

Fixes #95