### PR TITLE
feat: add -q shortcut and --info-only flag

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -36,7 +36,7 @@ or checking data integrity after moving files.`,
 func init() {
 	checkCmd.Flags().SortFlags = false
 	checkCmd.Flags().BoolVarP(&checkOpts.Verbose, "verbose", "v", false, "show list of bad piece indices")
-	checkCmd.Flags().BoolVar(&checkOpts.Quiet, "quiet", false, "reduced output mode (prints only completion percentage)")
+	checkCmd.Flags().BoolVarP(&checkOpts.Quiet, "quiet", "q", false, "reduced output mode (prints only completion percentage)")
 	checkCmd.Flags().IntVar(&checkOpts.Workers, "workers", 0, "number of worker goroutines for verification (0 for automatic)")
 	checkCmd.SetUsageTemplate(`Usage:
   {{.CommandPath}} <torrent-file> <content-path> [flags]

--- a/cmd/modify.go
+++ b/cmd/modify.go
@@ -63,7 +63,7 @@ func init() {
 	modifyCmd.Flags().StringVarP(&modifyOpts.Source, "source", "s", "", "add source string")
 	modifyCmd.Flags().BoolVarP(&modifyOpts.Entropy, "entropy", "e", false, "randomize info hash by adding entropy field")
 	modifyCmd.Flags().BoolVarP(&modifyOpts.Verbose, "verbose", "v", false, "be verbose")
-	modifyCmd.Flags().BoolVar(&modifyOpts.Quiet, "quiet", false, "reduced output mode (prints only final torrent paths)")
+	modifyCmd.Flags().BoolVarP(&modifyOpts.Quiet, "quiet", "q", false, "reduced output mode (prints only final torrent paths)")
 	modifyCmd.Flags().BoolVarP(&modifyOpts.SkipPrefix, "skip-prefix", "", false, "don't add tracker domain prefix to output filename")
 	modifyCmd.Flags().BoolVarP(&modifyOpts.DryRun, "dry-run", "n", false, "show what would be modified without making changes")
 

--- a/internal/torrent/batch.go
+++ b/internal/torrent/batch.go
@@ -36,7 +36,7 @@ type BatchJob struct {
 }
 
 // ToCreateOptions converts a BatchJob to CreateTorrentOptions
-func (j *BatchJob) ToCreateOptions(verbose bool, quiet bool, version string) CreateTorrentOptions {
+func (j *BatchJob) ToCreateOptions(verbose bool, quiet bool, infoOnly bool, version string) CreateTorrentOptions {
 	opts := CreateTorrentOptions{
 		Path:                    j.Path,
 		Name:                    j.Name,
@@ -48,6 +48,7 @@ func (j *BatchJob) ToCreateOptions(verbose bool, quiet bool, version string) Cre
 		NoDate:                  j.NoDate,
 		Verbose:                 verbose,
 		Quiet:                   quiet,
+		InfoOnly:                infoOnly,
 		Version:                 version,
 		SkipPrefix:              j.SkipPrefix,
 		ExcludePatterns:         j.ExcludePatterns,
@@ -73,7 +74,7 @@ type BatchResult struct {
 }
 
 // ProcessBatch processes a batch configuration file and creates multiple torrents
-func ProcessBatch(configPath string, verbose bool, quiet bool, version string) ([]BatchResult, error) {
+func ProcessBatch(configPath string, verbose bool, quiet bool, infoOnly bool, version string) ([]BatchResult, error) {
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read batch config: %w", err)
@@ -112,7 +113,7 @@ func ProcessBatch(configPath string, verbose bool, quiet bool, version string) (
 		go func() {
 			defer wg.Done()
 			for idx := range jobs {
-				results[idx] = processJob(config.Jobs[idx], verbose, quiet, version)
+				results[idx] = processJob(config.Jobs[idx], verbose, quiet, infoOnly, version)
 			}
 		}()
 	}
@@ -147,7 +148,7 @@ func validateJob(job BatchJob) error {
 	return nil
 }
 
-func processJob(job BatchJob, verbose bool, quiet bool, version string) BatchResult {
+func processJob(job BatchJob, verbose bool, quiet bool, infoOnly bool, version string) BatchResult {
 	result := BatchResult{
 		Job:      job,
 		Trackers: job.Trackers,
@@ -176,7 +177,7 @@ func processJob(job BatchJob, verbose bool, quiet bool, version string) BatchRes
 	}
 
 	// convert job to CreateTorrentOptions
-	opts := job.ToCreateOptions(verbose, quiet, version)
+	opts := job.ToCreateOptions(verbose, quiet, infoOnly, version)
 
 	// create the torrent
 	mi, err := CreateTorrent(opts)

--- a/internal/torrent/batch_test.go
+++ b/internal/torrent/batch_test.go
@@ -74,7 +74,7 @@ jobs:
 	}
 
 	// process batch
-	results, err := ProcessBatch(configPath, true, false, "test-version")
+	results, err := ProcessBatch(configPath, true, false, false, "test-version")
 	if err != nil {
 		t.Fatalf("ProcessBatch failed: %v", err)
 	}
@@ -181,7 +181,7 @@ jobs: []`,
 				t.Fatalf("Failed to write config file: %v", err)
 			}
 
-			_, err = ProcessBatch(configPath, false, false, "test-version")
+			_, err = ProcessBatch(configPath, false, false, false, "test-version")
 			if tt.expectError && err == nil {
 				t.Error("Expected error but got nil")
 			}

--- a/internal/torrent/types.go
+++ b/internal/torrent/types.go
@@ -28,6 +28,7 @@ type CreateTorrentOptions struct {
 	Verbose                 bool
 	Entropy                 bool
 	Quiet                   bool
+	InfoOnly                bool
 	SkipPrefix              bool
 	FailOnSeasonPackWarning bool
 }


### PR DESCRIPTION
## Summary
- Add `-q` as shortcut for `--quiet` flag across all relevant commands
- Add `--info-only`/`-i` flag to display only torrent metadata without progress bars
- Disable colors in info-only mode for clean log file output

## Details
The `--info-only` flag addresses the need for automation-friendly output by:
- Showing only the torrent info section (name, hash, size, etc.)
- Suppressing all progress bars and file tree display
- Disabling colors for clean log output
- Still showing the final "Wrote" line with elapsed time

Closes #101