### PR TITLE
fix(create): Do not create announce list for single tracker

### DIFF
--- a/torrent/create.go
+++ b/torrent/create.go
@@ -155,8 +155,10 @@ func CreateTorrent(opts CreateOptions) (*Torrent, error) {
 	// Set tracker information
 	if len(opts.TrackerURLs) > 0 {
 		mi.Announce = opts.TrackerURLs[0]
-		// Create announce list with all trackers in a single tier
-		mi.AnnounceList = [][]string{opts.TrackerURLs}
+		if (len(opts.TrackerURLs) > 1) {
+			// Create announce list with all trackers in a single tier
+			mi.AnnounceList = [][]string{opts.TrackerURLs}
+		}
 	}
 
 	if !opts.NoCreator {

--- a/torrent/create_test.go
+++ b/torrent/create_test.go
@@ -405,7 +405,7 @@ func TestCreate_MultipleTrackers(t *testing.T) {
 			}
 
 			// Check announce list
-			if len(tt.trackers) > 0 {
+			if len(tt.trackers) > 1 {
 				if mi.AnnounceList == nil || len(mi.AnnounceList) != 1 {
 					t.Errorf("Expected AnnounceList with 1 tier, got %v", mi.AnnounceList)
 				} else if len(mi.AnnounceList[0]) != tt.expectedListCount {


### PR DESCRIPTION
When using a single tracker during torrent creation, it adds an `AnnounceList` with a single item which gets reported by some NexusPHP versions as "multi-tracker torrent" even when they contain only one element.

Torrent created with `mktorrent`:
```
$ mktorrent -p -a http://example.com README.md
$ mkbrr inspect mktorrent.torrent

Torrent info:
  Name: README.md
  Hash: b6ebbd9ca2d00571baf97bcf3baa4cbff204c545
  Size: 19 KiB
  Piece length: 256 KiB
  Pieces: 1
  Tracker: http://example.com
  Private: yes
  Created by: mktorrent 1.1
```

Torrent created with current `mkbrr`:

```
$ mkbrr create README.md -t http://example.com -o mkbrr.torrent
$ mkbrr inspect mkbrr.torrent

Torrent info:
  Name: README.md
  Hash: 6fb5f97b658ac86b170ec2b141fc71363d67c4b9
  Size: 19 KiB
  Piece length: 32 KiB
  Pieces: 1
  Trackers:
    http://example.com
  Private: yes
  Created by: mkbrr/v1.16.0 (https://github.com/autobrr/mkbrr)
```

Torrent created with `mkbrr` with my changes:

```
$ go run . create README.md -t http://example.com -o mkbrr-single.torrent
$ mkbrr inspect mkbrr-single.torrent

Torrent info:
  Name: README.md
  Hash: 6fb5f97b658ac86b170ec2b141fc71363d67c4b9
  Size: 19 KiB
  Piece length: 32 KiB
  Pieces: 1
  Tracker: http://example.com
  Private: yes
  Created by: mkbrr/(devel) (https://github.com/autobrr/mkbrr)
```

This fixes a bug introduced in #99 