### PR TITLE
fix(create): set default workers in profile

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -274,6 +274,10 @@ func buildCreateOptions(cmd *cobra.Command, inputPath string, opts createOptions
 				createOpts.IncludePatterns = append(slices.Clone(presetOpts.IncludePatterns), createOpts.IncludePatterns...)
 			}
 		}
+
+		if presetOpts.Workers != 0 && !cmd.Flags().Changed("workers") {
+			createOpts.Workers = presetOpts.Workers
+		}
 	}
 
 	// Check for tracker's default source only if no source is set by flag or preset


### PR DESCRIPTION
Fixes: #114 

The `CreateOpts.Workers` was not updated with resolved preset value in `create` command.