### PR TITLE
feat(release): add homebrew binary formula generation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -87,3 +87,19 @@ nfpms:
       - deb
       - rpm
       - archlinux
+
+brews:
+  - name: mkbrr
+    repository:
+      owner: autobrr
+      name: homebrew-mkbrr
+      branch: main
+    directory: Formula
+    homepage: "https://github.com/autobrr/mkbrr"
+    description: "Command-line tool for creating, modifying and inspecting torrent files"
+    license: "GPL-2.0-or-later"
+    commit_msg_template: "chore: update formula for {{ .ProjectName }} version {{ .Tag }}"
+    install: |
+      bin.install "mkbrr"
+    test: |
+      system "#{bin}/mkbrr", "version"


### PR DESCRIPTION
## Summary
- Adds `brews:` section to goreleaser config
- Formula downloads pre-built binaries instead of building from source
- Supports macOS (arm64, x86_64) and Linux (x86_64, arm64, arm)
- Auto-updates `autobrr/homebrew-mkbrr` on each release

## Benefits
- Faster installation (no compilation)
- No Go dependency required
- Users get PGO-optimized binaries

## Token Requirements
Goreleaser needs write access to `autobrr/homebrew-mkbrr`. Options:

1. **GitHub Actions token** - Grant the release workflow's `GITHUB_TOKEN` `contents: write` on the tap repo
2. **Classic PAT** via `HOMEBREW_TAP_GITHUB_TOKEN` - Needs `public_repo` scope (or `repo` if tap is private)