### PR TITLE
chore: replace custom min/max with go1.21+ native builtins

### DIFF
--- a/torrent/batch.go
+++ b/torrent/batch.go
@@ -106,7 +106,7 @@ func ProcessBatch(configPath string, verbose bool, quiet bool, infoOnly bool, ve
 	var wg sync.WaitGroup
 
 	// process jobs in parallel with a worker pool
-	workers := minInt(len(config.Jobs), 4) // limit concurrent jobs
+	workers := min(len(config.Jobs), 4) // limit concurrent jobs
 	jobs := make(chan int, len(config.Jobs))
 
 	// start workers

--- a/torrent/create.go
+++ b/torrent/create.go
@@ -17,14 +17,6 @@ import (
 	"github.com/autobrr/mkbrr/internal/trackers"
 )
 
-// max returns the larger of x or y
-func max(x, y int64) int64 {
-	if x > y {
-		return x
-	}
-	return y
-}
-
 // formatPieceSize returns a human readable piece size, using KiB for sizes < 1024 KiB and MiB for larger sizes
 func formatPieceSize(exp uint) string {
 	size := uint64(1) << (exp - 10) // convert to KiB
@@ -49,12 +41,7 @@ func calculatePieceLength(totalSize int64, maxPieceLength *uint, trackerURLs []s
 		// check if tracker has specific piece size ranges
 		if exp, ok := trackers.GetTrackerPieceSizeExp(trackerURLs[0], uint64(totalSize)); ok {
 			// ensure we stay within bounds
-			if exp < minExp {
-				exp = minExp
-			}
-			if exp > maxExp {
-				exp = maxExp
-			}
+			exp = min(max(exp, minExp), maxExp)
 			if verbose {
 				display := NewDisplay(NewFormatter(verbose))
 				display.ShowMessage(fmt.Sprintf("using tracker-specific range for content size: %d MiB (recommended: %s pieces)",
@@ -69,11 +56,7 @@ func calculatePieceLength(totalSize int64, maxPieceLength *uint, trackerURLs []s
 		if *maxPieceLength < minExp {
 			return minExp
 		}
-		if *maxPieceLength > 27 {
-			maxExp = 27
-		} else {
-			maxExp = *maxPieceLength
-		}
+		maxExp = min(*maxPieceLength, 27)
 	}
 
 	// default calculation for automatic piece length
@@ -111,14 +94,12 @@ func calculatePieceLength(totalSize int64, maxPieceLength *uint, trackerURLs []s
 	}
 
 	// if no manual piece length was specified, cap at 2^24
-	if maxPieceLength == nil && exp > 24 {
-		exp = 24
+	if maxPieceLength == nil {
+		exp = min(exp, 24)
 	}
 
 	// ensure we stay within bounds
-	if exp > maxExp {
-		exp = maxExp
-	}
+	exp = min(exp, maxExp)
 
 	return exp
 }

--- a/torrent/hasher.go
+++ b/torrent/hasher.go
@@ -336,11 +336,3 @@ func NewPieceHasher(files []fileEntry, pieceLen int64, numPieces int, display Di
 		failOnSeasonPackWarning: failOnSeasonPackWarning,
 	}
 }
-
-// minInt returns the smaller of two integers
-func minInt(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}

--- a/torrent/seasonfinder.go
+++ b/torrent/seasonfinder.go
@@ -47,7 +47,7 @@ func AnalyzeSeasonPack(files []fileEntry) *SeasonPackInfo {
 	season := detectSeasonNumber(dirPath)
 
 	if season == 0 && len(files) > 1 {
-		for i := 0; i < minInt(5, len(files)); i++ {
+		for i := 0; i < min(5, len(files)); i++ {
 			if s, _ := extractSeasonEpisode(filepath.Base(files[i].path)); s > 0 {
 				season = s
 				break


### PR DESCRIPTION
Just a minor chore, I'd say, to improve codebase

https://go.dev/ref/spec#Min_and_max

* Remove custom max(x, y int64) from create.go
* Remove custom minInt(a, b int) from hasher.go
* Update call sites in batch.go, seasonfinder.go, create.go
* Refactor clamping patterns to use min/max composition

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code refactoring to streamline helper functions and improve code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->