### PR TITLE
Update installation instructions for Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ Download a ready-to-use binary for your platform from the [releases page](https:
 ### Homebrew (macOS and Linux)
 
 ```bash
-brew tap autobrr/mkbrr
 brew install mkbrr
 ```
 


### PR DESCRIPTION
Mkbrr is now [available](https://github.com/Homebrew/homebrew-core/commit/71fd25a5f78ada840872c836faa7f5459929d59f) directly via [Homebrew](https://brew.sh/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to simplify the setup process. Users can now install mkbrr with a single, straightforward command, eliminating additional preliminary steps previously required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->