### PR TITLE
feat(trackers): add onlyencodes piece rules

### DIFF
--- a/internal/trackers/trackers.go
+++ b/internal/trackers/trackers.go
@@ -25,14 +25,14 @@ var trackerConfigs = []TrackerConfig{
 			"anthelion.me",
 		},
 		MaxTorrentSize: 250 << 10, // 250 KiB torrent file size limit
-		DefaultSource: "ANT",
+		DefaultSource:  "ANT",
 	},
 	{
 		URLs: []string{
 			"nebulance.io",
 		},
 		MaxTorrentSize: 1024 << 10, // 1 MiB torrent file size limit
-		DefaultSource: "NBL",
+		DefaultSource:  "NBL",
 	},
 	{
 		URLs: []string{
@@ -205,7 +205,21 @@ var trackerConfigs = []TrackerConfig{
 		},
 		UseDefaultRanges: false,
 	},
-		{
+	{
+		URLs: []string{
+			"onlyencodes.cc",
+		},
+		MaxPieceLength: 24, // max 16 MiB pieces (2^24)
+		PieceSizeRanges: []PieceSizeRange{
+			{MaxSize: 1024 << 20, PieceExp: 20},  // 1 MiB < 1 GB
+			{MaxSize: 4096 << 20, PieceExp: 21},  // 2 MiB for 1-4 GB
+			{MaxSize: 12288 << 20, PieceExp: 22}, // 4 MiB for 4-12 GB
+			{MaxSize: 20480 << 20, PieceExp: 23}, // 8 MiB for 12-20 GB
+			{MaxSize: ^uint64(0), PieceExp: 24},  // 16 MiB for > 20 GB
+		},
+		UseDefaultRanges: false,
+	},
+	{
 		URLs: []string{
 			"lst.gg",
 		},
@@ -263,7 +277,7 @@ var trackerConfigs = []TrackerConfig{
 			{MaxSize: ^uint64(0), PieceExp: 24},  // 16 MiB for 16+ GiB
 		},
 		UseDefaultRanges: false,
-		DefaultSource: "TorrentLeech.org",
+		DefaultSource:    "TorrentLeech.org",
 	},
 }
 

--- a/internal/trackers/trackers_test.go
+++ b/internal/trackers/trackers_test.go
@@ -76,6 +76,13 @@ func Test_GetTrackerPieceSizeExp(t *testing.T) {
 			wantFound:   true,
 		},
 		{
+			name:        "onlyencodes should use lst piece rules",
+			trackerURL:  "https://onlyencodes.cc/announce?passkey=123",
+			contentSize: 8 << 30, // 8 GB
+			wantExp:     22,      // 4 MiB pieces
+			wantFound:   true,
+		},
+		{
 			name:        "unknown tracker should not return piece size recommendations",
 			trackerURL:  "https://unknown.tracker/announce",
 			contentSize: 1 << 30,
@@ -143,6 +150,12 @@ func Test_GetTrackerMaxPieceLength(t *testing.T) {
 		{
 			name:       "torrent-syndikat alternate domain should allow up to 16 MiB pieces",
 			trackerURL: "https://ulo.tee-stube.org/ts_ann.php?passkey=123",
+			wantExp:    24, // 16 MiB pieces
+			wantFound:  true,
+		},
+		{
+			name:       "onlyencodes should allow up to 16 MiB pieces",
+			trackerURL: "https://onlyencodes.cc/announce?passkey=123",
 			wantExp:    24, // 16 MiB pieces
 			wantFound:  true,
 		},


### PR DESCRIPTION
Adds onlyencodes.cc as a tracker with the same piece-size ladder and 16 MiB max piece length as lst.gg, plus regression coverage for lookup behavior. Validated with go test ./internal/trackers, make test, and make build. Closes #149.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added support for the `onlyencodes.cc` tracker with custom piece sizing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->