### PR TITLE
fix: add entropy support to batch mode

### DIFF
--- a/schema/batch.json
+++ b/schema/batch.json
@@ -65,6 +65,11 @@
             "description": "Don't write creation date",
             "default": false
           },
+          "entropy": {
+            "type": "boolean",
+            "description": "Randomize info hash by adding entropy field",
+            "default": false
+          },
           "exclude_patterns": {
             "type": "array",
             "description": "List of glob patterns to exclude files (e.g., \"*.nfo\", \"*sample*\")",

--- a/torrent/batch.go
+++ b/torrent/batch.go
@@ -32,6 +32,7 @@ type BatchJob struct {
 	Private             bool     `yaml:"private"`
 	NoDate              bool     `yaml:"no_date"`
 	SkipPrefix          bool     `yaml:"skip_prefix"`
+	Entropy             bool     `yaml:"entropy"`
 	FailOnSeasonWarning bool     `yaml:"fail_on_season_warning"`
 }
 
@@ -51,6 +52,7 @@ func (j *BatchJob) ToCreateOptions(verbose bool, quiet bool, infoOnly bool, vers
 		InfoOnly:                infoOnly,
 		Version:                 version,
 		SkipPrefix:              j.SkipPrefix,
+		Entropy:                 j.Entropy,
 		ExcludePatterns:         j.ExcludePatterns,
 		IncludePatterns:         j.IncludePatterns,
 		FailOnSeasonPackWarning: j.FailOnSeasonWarning,

--- a/torrent/batch_test.go
+++ b/torrent/batch_test.go
@@ -123,6 +123,62 @@ jobs:
 	}
 }
 
+func TestBatchEntropy(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "mkbrr-batch-entropy")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// create a test file
+	testFile := filepath.Join(tmpDir, "file.txt")
+	if err := os.WriteFile(testFile, []byte("test content for entropy"), 0644); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	// create batch config with entropy enabled
+	configPath := filepath.Join(tmpDir, "batch.yaml")
+	configContent := []byte(fmt.Sprintf(`version: 1
+jobs:
+  - output: %s
+    path: %s
+    entropy: true
+    piece_length: 16
+  - output: %s
+    path: %s
+    entropy: false
+    piece_length: 16
+`,
+		filepath.Join(tmpDir, "with_entropy.torrent"),
+		testFile,
+		filepath.Join(tmpDir, "without_entropy.torrent"),
+		testFile))
+
+	if err := os.WriteFile(configPath, configContent, 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	results, err := ProcessBatch(configPath, false, false, false, "test-version")
+	if err != nil {
+		t.Fatalf("ProcessBatch failed: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("Expected 2 results, got %d", len(results))
+	}
+
+	for i, result := range results {
+		if !result.Success {
+			t.Fatalf("Job %d failed: %v", i, result.Error)
+		}
+	}
+
+	// the two torrents should have different info hashes because one has entropy
+	if results[0].Info.InfoHash == results[1].Info.InfoHash {
+		t.Error("Expected different info hashes when entropy is enabled vs disabled")
+	}
+}
+
 func TestBatchValidation(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
The `entropy` option was wired up for single-torrent creation and presets but never made it into the `BatchJob` struct, so setting `entropy: true` in a batch YAML config was silently ignored. This adds the field, maps it through to `CreateOptions`, updates the batch JSON schema, and includes a test that verifies two identical jobs produce different info hashes when one has entropy enabled.

Closes #140

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an `entropy` configuration option for batch jobs. When enabled, it randomizes the torrent info hash generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->