### PR TITLE
fix(tracker): increase TorrentLeech max piece length from 2^24 to 2^27

### DIFF
--- a/internal/trackers/trackers.go
+++ b/internal/trackers/trackers.go
@@ -276,8 +276,8 @@ var trackerConfigs = []TrackerConfig{
 			{MaxSize: 16384 << 20, PieceExp: 23},  // 8 MiB for 8-16 GiB
 			{MaxSize: 32768 << 20, PieceExp: 24},  // 16 MiB for 16-32 GiB
 			{MaxSize: 65536 << 20, PieceExp: 25},  // 32 MiB for 32-64 GiB
-			{MaxSize: 131072 << 20, PieceExp: 26}, // 64 MiB for 64-128 GiB
-			{MaxSize: ^uint64(0), PieceExp: 27},   // 128 MiB for 128+ GiB
+			{MaxSize: 122880 << 20, PieceExp: 26}, // 64 MiB for 64-120 GiB
+			{MaxSize: ^uint64(0), PieceExp: 27},   // 128 MiB for 120+ GiB (TL supports 2^28 but mkbrr caps at 2^27)
 		},
 		UseDefaultRanges: false,
 		DefaultSource:    "TorrentLeech.org",

--- a/internal/trackers/trackers.go
+++ b/internal/trackers/trackers.go
@@ -263,18 +263,21 @@ var trackerConfigs = []TrackerConfig{
 			"tracker.torrentleech.org",
 			"tracker.tleechreload.org",
 		},
-		MaxPieceLength: 24, // max 16 MiB pieces (2^24)
+		MaxPieceLength: 27, // max 128 MiB pieces (2^27)
 		PieceSizeRanges: []PieceSizeRange{
-			{MaxSize: 50 << 20, PieceExp: 15},    // 32 KiB for <= 50 MiB
-			{MaxSize: 150 << 20, PieceExp: 16},   // 64 KiB for 50-150 MiB
-			{MaxSize: 350 << 20, PieceExp: 17},   // 128 KiB for 150-350 MiB
-			{MaxSize: 512 << 20, PieceExp: 18},   // 256 KiB for 350-512 MiB
-			{MaxSize: 1024 << 20, PieceExp: 19},  // 512 KiB for 512 MiB-1 GiB
-			{MaxSize: 2048 << 20, PieceExp: 20},  // 1 MiB for 1-2 GiB
-			{MaxSize: 4096 << 20, PieceExp: 21},  // 2 MiB for 2-4 GiB
-			{MaxSize: 8192 << 20, PieceExp: 22},  // 4 MiB for 4-8 GiB
-			{MaxSize: 16384 << 20, PieceExp: 23}, // 8 MiB for 8-16 GiB
-			{MaxSize: ^uint64(0), PieceExp: 24},  // 16 MiB for 16+ GiB
+			{MaxSize: 50 << 20, PieceExp: 15},     // 32 KiB for <= 50 MiB
+			{MaxSize: 150 << 20, PieceExp: 16},    // 64 KiB for 50-150 MiB
+			{MaxSize: 350 << 20, PieceExp: 17},    // 128 KiB for 150-350 MiB
+			{MaxSize: 512 << 20, PieceExp: 18},    // 256 KiB for 350-512 MiB
+			{MaxSize: 1024 << 20, PieceExp: 19},   // 512 KiB for 512 MiB-1 GiB
+			{MaxSize: 2048 << 20, PieceExp: 20},   // 1 MiB for 1-2 GiB
+			{MaxSize: 4096 << 20, PieceExp: 21},   // 2 MiB for 2-4 GiB
+			{MaxSize: 8192 << 20, PieceExp: 22},   // 4 MiB for 4-8 GiB
+			{MaxSize: 16384 << 20, PieceExp: 23},  // 8 MiB for 8-16 GiB
+			{MaxSize: 32768 << 20, PieceExp: 24},  // 16 MiB for 16-32 GiB
+			{MaxSize: 65536 << 20, PieceExp: 25},  // 32 MiB for 32-64 GiB
+			{MaxSize: 131072 << 20, PieceExp: 26}, // 64 MiB for 64-128 GiB
+			{MaxSize: ^uint64(0), PieceExp: 27},   // 128 MiB for 128+ GiB
 		},
 		UseDefaultRanges: false,
 		DefaultSource:    "TorrentLeech.org",

--- a/torrent/create.go
+++ b/torrent/create.go
@@ -151,11 +151,6 @@ func calculatePieceLength(totalSize int64, maxPieceLength *uint, trackerURLs []s
 		exp = 27
 	}
 
-	// if no manual piece length was specified, cap at 2^24
-	if maxPieceLength == nil {
-		exp = min(exp, 24)
-	}
-
 	// ensure we stay within bounds
 	exp = min(exp, maxExp)
 
@@ -549,8 +544,19 @@ func CreateTorrent(opts CreateOptions) (*Torrent, error) {
 				return nil, fmt.Errorf("error marshaling torrent data: %w", err)
 			}
 
+			// Determine the effective max piece length ceiling
+			maxPieceLengthCeiling := uint(24) // default ceiling
+			if len(opts.TrackerURLs) > 0 && opts.TrackerURLs[0] != "" {
+				if trackerMaxExp, ok := trackers.GetTrackerMaxPieceLength(opts.TrackerURLs[0]); ok {
+					maxPieceLengthCeiling = trackerMaxExp
+				}
+			}
+			if opts.MaxPieceLength != nil && *opts.MaxPieceLength < maxPieceLengthCeiling {
+				maxPieceLengthCeiling = *opts.MaxPieceLength
+			}
+
 			// If it exceeds limit, try increasing piece length until it fits or we hit max
-			for uint64(len(torrentData)) > maxSize && pieceLength < 24 {
+			for uint64(len(torrentData)) > maxSize && pieceLength < maxPieceLengthCeiling {
 				if opts.Verbose || opts.InfoOnly {
 					display := NewDisplay(NewFormatter(opts.Verbose || opts.InfoOnly))
 					display.SetQuiet(opts.Quiet || opts.InfoOnly)

--- a/torrent/create.go
+++ b/torrent/create.go
@@ -545,14 +545,22 @@ func CreateTorrent(opts CreateOptions) (*Torrent, error) {
 			}
 
 			// Determine the effective max piece length ceiling
-			maxPieceLengthCeiling := uint(27) // absolute max 128 MiB
+			maxPieceLengthCeiling := uint(24) // default ceiling
+			hasTrackerCap := false
 			if len(opts.TrackerURLs) > 0 && opts.TrackerURLs[0] != "" {
 				if trackerMaxExp, ok := trackers.GetTrackerMaxPieceLength(opts.TrackerURLs[0]); ok {
 					maxPieceLengthCeiling = trackerMaxExp
+					hasTrackerCap = true
 				}
 			}
-			if opts.MaxPieceLength != nil && *opts.MaxPieceLength < maxPieceLengthCeiling {
-				maxPieceLengthCeiling = *opts.MaxPieceLength
+			if opts.MaxPieceLength != nil {
+				if hasTrackerCap {
+					// tracker cap is a hard ceiling; user can lower but not exceed it
+					maxPieceLengthCeiling = min(*opts.MaxPieceLength, maxPieceLengthCeiling)
+				} else {
+					// no tracker cap; user can raise above default 24
+					maxPieceLengthCeiling = min(*opts.MaxPieceLength, 27)
+				}
 			}
 
 			// If it exceeds limit, try increasing piece length until it fits or we hit max

--- a/torrent/create.go
+++ b/torrent/create.go
@@ -545,7 +545,7 @@ func CreateTorrent(opts CreateOptions) (*Torrent, error) {
 			}
 
 			// Determine the effective max piece length ceiling
-			maxPieceLengthCeiling := uint(24) // default ceiling
+			maxPieceLengthCeiling := uint(27) // absolute max 128 MiB
 			if len(opts.TrackerURLs) > 0 && opts.TrackerURLs[0] != "" {
 				if trackerMaxExp, ok := trackers.GetTrackerMaxPieceLength(opts.TrackerURLs[0]); ok {
 					maxPieceLengthCeiling = trackerMaxExp


### PR DESCRIPTION
TorrentLeech documents piece sizes up to 2^28 (256 MiB), but mkbrr was incorrectly limiting it to 2^24 (16 MiB). This updates `MaxPieceLength` to 2^27 (128 MiB), the maximum mkbrr supports, and extends the `PieceSizeRanges` to match TorrentLeech's documented piece size table exactly, including the 120 GiB boundary for 64 MiB pieces.

Closes #159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased supported piece sizes for a specific tracker to allow up to 128 MiB pieces.

* **Bug Fixes / Enhancements**
  * Torrent creation now respects tracker and user max piece-size limits, removing a previous hard cap so large torrents can select appropriate piece sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->