### PR TITLE
fix(gui): prevent blank screen in GUI when all presets are deleted

### DIFF
--- a/gui/app.go
+++ b/gui/app.go
@@ -556,7 +556,7 @@ func (a *App) ListPresets() ([]string, error) {
 		return nil, err
 	}
 
-	var names []string
+	names := make([]string, 0, len(config.Presets))
 	for name := range config.Presets {
 		names = append(names, name)
 	}

--- a/gui/frontend/pnpm-workspace.yaml
+++ b/gui/frontend/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/gui/frontend/pnpm-workspace.yaml
+++ b/gui/frontend/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-allowBuilds:
-  esbuild: true

--- a/gui/frontend/src/pages/Create.tsx
+++ b/gui/frontend/src/pages/Create.tsx
@@ -163,7 +163,7 @@ export function CreatePage() {
   const [dialogOpen, setDialogOpen] = useState(false);
 
   useEffect(() => {
-    ListPresets().then(setPresets).catch((e) => toast.error('Failed to load presets: ' + String(e)));
+    ListPresets().then((names) => setPresets(names ?? [])).catch((e) => toast.error('Failed to load presets: ' + String(e)));
   }, []);
 
   // Save form state to localStorage whenever values change


### PR DESCRIPTION
In Go, a nil slice marshals to null in JSON, not []. ListPresets() declared names as var names []string which stays nil when the presets map is empty, causing the JSON response to be null instead of [].

On the frontend, setPresets(null) replaced the string array state with null. Navigating to the Create page then crashed React with "Cannot read properties of null (reading 'length')" because presets.length was called on null, blanking the entire UI.

Fix: initialise names with make([]string, 0) so an empty list always marshals to []. Also add a nullish coalescing guard on the frontend as a defensive fallback.

Also add pnpm-workspace.yaml to allow esbuild build scripts, required by pnpm v10+ supply-chain policy checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Optimized preset loading and initialization.

* **Bug Fixes**
  * Improved reliability of preset loading with better error handling for edge cases.

* **Infrastructure**
  * Enhanced build configuration to enable additional optimization capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autobrr/mkbrr/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->