### PR TITLE
feat(gui): add drag and drop support

### DIFF
--- a/gui/frontend/pnpm-workspace.yaml
+++ b/gui/frontend/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/gui/frontend/pnpm-workspace.yaml
+++ b/gui/frontend/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-allowBuilds:
-  esbuild: true

--- a/gui/frontend/src/App.tsx
+++ b/gui/frontend/src/App.tsx
@@ -11,22 +11,27 @@ import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { WindowGetSize, WindowSetSize } from '../wailsjs/runtime/runtime';
 
 const WINDOW_SIZE_KEY = 'mkbrr-window-size';
+// Mirror MinWidth/MinHeight in gui/main.go — keep these in sync.
 const MIN_WIDTH = 900;
 const MIN_HEIGHT = 600;
 
 function App() {
   // Restore saved window size on startup, and persist it whenever the window is resized.
   useEffect(() => {
-    const saved = localStorage.getItem(WINDOW_SIZE_KEY);
-    if (saved) {
-      try {
+    try {
+      const saved = localStorage.getItem(WINDOW_SIZE_KEY);
+      if (saved) {
         const { w, h } = JSON.parse(saved);
-        if (w >= MIN_WIDTH && h >= MIN_HEIGHT) {
-          WindowSetSize(w, h);
+        if (Number.isFinite(w) && Number.isFinite(h) && w >= MIN_WIDTH && h >= MIN_HEIGHT) {
+          // Clamp to the available screen so a size saved on a larger display
+          // can't restore the window oversized or off-screen.
+          const maxW = window.screen.availWidth || w;
+          const maxH = window.screen.availHeight || h;
+          WindowSetSize(Math.min(w, maxW), Math.min(h, maxH));
         }
-      } catch {
-        // Ignore malformed data.
       }
+    } catch {
+      // Ignore malformed data or unavailable storage.
     }
 
     let saveTimer: ReturnType<typeof setTimeout>;

--- a/gui/frontend/src/App.tsx
+++ b/gui/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { Layout } from '@/components/layout/Layout';
 import { CreatePage } from '@/pages/Create';
@@ -6,8 +7,47 @@ import { CheckPage } from '@/pages/Check';
 import { ModifyPage } from '@/pages/Modify';
 import { SettingsPage } from '@/pages/Settings';
 import { Toaster } from '@/components/ui/sonner';
+import { WindowGetSize, WindowSetSize } from '../wailsjs/runtime/runtime';
+
+const WINDOW_SIZE_KEY = 'mkbrr-window-size';
+const MIN_WIDTH = 900;
+const MIN_HEIGHT = 600;
 
 function App() {
+  // Restore saved window size on startup, and persist it whenever the window is resized.
+  useEffect(() => {
+    const saved = localStorage.getItem(WINDOW_SIZE_KEY);
+    if (saved) {
+      try {
+        const { w, h } = JSON.parse(saved);
+        if (w >= MIN_WIDTH && h >= MIN_HEIGHT) {
+          WindowSetSize(w, h);
+        }
+      } catch {
+        // Ignore malformed data.
+      }
+    }
+
+    let saveTimer: ReturnType<typeof setTimeout>;
+    const handleResize = () => {
+      clearTimeout(saveTimer);
+      saveTimer = setTimeout(async () => {
+        try {
+          const size = await WindowGetSize();
+          localStorage.setItem(WINDOW_SIZE_KEY, JSON.stringify(size));
+        } catch {
+          // Ignore – non-critical.
+        }
+      }, 300);
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      clearTimeout(saveTimer);
+    };
+  }, []);
+
   return (
     <BrowserRouter>
       <Routes>

--- a/gui/frontend/src/components/ui/drop-overlay.tsx
+++ b/gui/frontend/src/components/ui/drop-overlay.tsx
@@ -1,0 +1,23 @@
+import { Upload } from 'lucide-react';
+
+interface DropOverlayProps {
+  visible: boolean;
+  label?: string;
+}
+
+/**
+ * Full-screen overlay displayed while the user drags files over the window.
+ * Rendered via a React portal so it sits above all page content.
+ */
+export function DropOverlay({ visible, label = 'Drop files here' }: DropOverlayProps) {
+  if (!visible) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm pointer-events-none">
+      <div className="flex flex-col items-center gap-4 px-16 py-12 rounded-2xl border-2 border-dashed border-primary/60 bg-card/90 shadow-2xl">
+        <Upload className="h-14 w-14 text-primary/70" />
+        <p className="text-lg font-semibold text-foreground/80">{label}</p>
+      </div>
+    </div>
+  );
+}

--- a/gui/frontend/src/components/ui/drop-overlay.tsx
+++ b/gui/frontend/src/components/ui/drop-overlay.tsx
@@ -7,7 +7,7 @@ interface DropOverlayProps {
 
 /**
  * Full-screen overlay displayed while the user drags files over the window.
- * Rendered via a React portal so it sits above all page content.
+ * Uses fixed positioning (z-50) to sit above all page content.
  */
 export function DropOverlay({ visible, label = 'Drop files here' }: DropOverlayProps) {
   if (!visible) return null;

--- a/gui/frontend/src/hooks/useFileDrop.ts
+++ b/gui/frontend/src/hooks/useFileDrop.ts
@@ -1,0 +1,70 @@
+import { useEffect, useRef, useState } from 'react';
+import { OnFileDrop, OnFileDropOff } from '../../wailsjs/runtime/runtime';
+
+/**
+ * Hook that registers Wails' native file drop handler and tracks drag state.
+ *
+ * @param onDrop - Callback invoked with the dropped file/folder paths.
+ * @returns { isDragging } - True while files are being dragged over the window.
+ */
+export function useFileDrop(onDrop: (paths: string[]) => void): { isDragging: boolean } {
+  const [isDragging, setIsDragging] = useState(false);
+
+  // Keep a stable ref so the effect closure never becomes stale.
+  const onDropRef = useRef(onDrop);
+  useEffect(() => {
+    onDropRef.current = onDrop;
+  });
+
+  useEffect(() => {
+    let counter = 0;
+
+    const handleDragEnter = (e: DragEvent) => {
+      if (!e.dataTransfer?.types.includes('Files')) return;
+      e.preventDefault();
+      counter++;
+      if (counter === 1) setIsDragging(true);
+    };
+
+    const handleDragLeave = () => {
+      counter = Math.max(0, counter - 1);
+      if (counter === 0) setIsDragging(false);
+    };
+
+    const handleDragOver = (e: DragEvent) => {
+      if (e.dataTransfer?.types.includes('Files')) {
+        e.preventDefault();
+      }
+    };
+
+    // Reset on native drop (Wails intercepts the actual data via OnFileDrop).
+    const handleDrop = () => {
+      counter = 0;
+      setIsDragging(false);
+    };
+
+    window.addEventListener('dragenter', handleDragEnter);
+    window.addEventListener('dragleave', handleDragLeave);
+    window.addEventListener('dragover', handleDragOver);
+    window.addEventListener('drop', handleDrop);
+
+    // Wails native file drop – gives us real filesystem paths.
+    OnFileDrop((_x, _y, paths) => {
+      counter = 0;
+      setIsDragging(false);
+      if (paths && paths.length > 0) {
+        onDropRef.current(paths);
+      }
+    }, false);
+
+    return () => {
+      window.removeEventListener('dragenter', handleDragEnter);
+      window.removeEventListener('dragleave', handleDragLeave);
+      window.removeEventListener('dragover', handleDragOver);
+      window.removeEventListener('drop', handleDrop);
+      OnFileDropOff();
+    };
+  }, []); // Intentionally empty – setup/teardown once per mount.
+
+  return { isDragging };
+}

--- a/gui/frontend/src/hooks/useFileDrop.ts
+++ b/gui/frontend/src/hooks/useFileDrop.ts
@@ -19,6 +19,12 @@ export function useFileDrop(onDrop: (paths: string[]) => void): { isDragging: bo
   useEffect(() => {
     let counter = 0;
 
+    // Force the overlay off regardless of the nesting counter.
+    const reset = () => {
+      counter = 0;
+      setIsDragging(false);
+    };
+
     const handleDragEnter = (e: DragEvent) => {
       if (!e.dataTransfer?.types.includes('Files')) return;
       e.preventDefault();
@@ -26,7 +32,22 @@ export function useFileDrop(onDrop: (paths: string[]) => void): { isDragging: bo
       if (counter === 1) setIsDragging(true);
     };
 
-    const handleDragLeave = () => {
+    const handleDragLeave = (e: DragEvent) => {
+      // A dragleave with no related target, or with coordinates outside the
+      // viewport, means the cursor actually left the window. Force-reset so the
+      // overlay can't get stuck if a final balanced dragleave is never delivered
+      // (a known cross-platform webview quirk). Otherwise just unwind the counter
+      // for normal transitions between nested elements.
+      if (
+        !e.relatedTarget ||
+        e.clientX <= 0 ||
+        e.clientY <= 0 ||
+        e.clientX >= window.innerWidth ||
+        e.clientY >= window.innerHeight
+      ) {
+        reset();
+        return;
+      }
       counter = Math.max(0, counter - 1);
       if (counter === 0) setIsDragging(false);
     };
@@ -37,21 +58,25 @@ export function useFileDrop(onDrop: (paths: string[]) => void): { isDragging: bo
       }
     };
 
-    // Reset on native drop (Wails intercepts the actual data via OnFileDrop).
-    const handleDrop = () => {
-      counter = 0;
-      setIsDragging(false);
+    // Mouse events only resume once no drag is in progress, so a plain
+    // mousemove while the overlay is up means a drag was cancelled (e.g. Esc)
+    // without firing drop/dragleave — clear the stranded overlay.
+    const handleMouseMove = () => {
+      if (counter !== 0) reset();
     };
 
     window.addEventListener('dragenter', handleDragEnter);
     window.addEventListener('dragleave', handleDragLeave);
     window.addEventListener('dragover', handleDragOver);
-    window.addEventListener('drop', handleDrop);
+    // Reset on native drop (Wails intercepts the actual data via OnFileDrop),
+    // on a cancelled drag, and as a fallback when the pointer returns.
+    window.addEventListener('drop', reset);
+    window.addEventListener('dragend', reset);
+    window.addEventListener('mousemove', handleMouseMove);
 
     // Wails native file drop – gives us real filesystem paths.
     OnFileDrop((_x, _y, paths) => {
-      counter = 0;
-      setIsDragging(false);
+      reset();
       if (paths && paths.length > 0) {
         onDropRef.current(paths);
       }
@@ -61,7 +86,9 @@ export function useFileDrop(onDrop: (paths: string[]) => void): { isDragging: bo
       window.removeEventListener('dragenter', handleDragEnter);
       window.removeEventListener('dragleave', handleDragLeave);
       window.removeEventListener('dragover', handleDragOver);
-      window.removeEventListener('drop', handleDrop);
+      window.removeEventListener('drop', reset);
+      window.removeEventListener('dragend', reset);
+      window.removeEventListener('mousemove', handleMouseMove);
       OnFileDropOff();
     };
   }, []); // Intentionally empty – setup/teardown once per mount.

--- a/gui/frontend/src/pages/Check.tsx
+++ b/gui/frontend/src/pages/Check.tsx
@@ -6,7 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Progress } from '@/components/ui/progress';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { FolderOpen, File, Loader2, CheckCircle, XCircle } from 'lucide-react';
+import { FolderOpen, File, Loader2, CheckCircle, XCircle, X } from 'lucide-react';
 import { SelectTorrentFile, SelectPath, SelectFile, VerifyTorrent } from '../../wailsjs/go/main/App';
 import { EventsOn } from '../../wailsjs/runtime/runtime';
 import { main } from '../../wailsjs/go/models';
@@ -183,13 +183,25 @@ export function CheckPage() {
             <div className="space-y-1.5">
               <Label>Torrent File</Label>
               <div className="flex gap-2">
-                <Input
-                  value={torrentPath}
-                  onChange={(e) => setTorrentPath(e.target.value)}
-                  placeholder="Select a .torrent file"
-                  className="flex-1"
-                />
-                <Button variant="outline" onClick={handleSelectTorrent}>
+                <div className="relative flex-1">
+                  <Input
+                    value={torrentPath}
+                    onChange={(e) => setTorrentPath(e.target.value)}
+                    placeholder="Select a .torrent file"
+                    className={torrentPath ? 'pr-8' : ''}
+                  />
+                  {torrentPath && (
+                    <button
+                      type="button"
+                      onClick={() => setTorrentPath('')}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                      title="Clear"
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
+                  )}
+                </div>
+                <Button variant="outline" size="icon" onClick={handleSelectTorrent}>
                   <FolderOpen className="h-4 w-4" />
                 </Button>
               </div>
@@ -199,12 +211,24 @@ export function CheckPage() {
             <div className="space-y-1.5">
               <Label>Content Path</Label>
               <div className="flex gap-2">
-                <Input
-                  value={contentPath}
-                  onChange={(e) => setContentPath(e.target.value)}
-                  placeholder="Select the content folder or file"
-                  className="flex-1"
-                />
+                <div className="relative flex-1">
+                  <Input
+                    value={contentPath}
+                    onChange={(e) => setContentPath(e.target.value)}
+                    placeholder="Select the content folder or file"
+                    className={contentPath ? 'pr-8' : ''}
+                  />
+                  {contentPath && (
+                    <button
+                      type="button"
+                      onClick={() => setContentPath('')}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                      title="Clear"
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
+                  )}
+                </div>
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button variant="outline" size="icon" onClick={handleSelectContentFile}>

--- a/gui/frontend/src/pages/Check.tsx
+++ b/gui/frontend/src/pages/Check.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -9,6 +10,8 @@ import { FolderOpen, File, Loader2, CheckCircle, XCircle } from 'lucide-react';
 import { SelectTorrentFile, SelectPath, SelectFile, VerifyTorrent } from '../../wailsjs/go/main/App';
 import { EventsOn } from '../../wailsjs/runtime/runtime';
 import { main } from '../../wailsjs/go/models';
+import { useFileDrop } from '@/hooks/useFileDrop';
+import { DropOverlay } from '@/components/ui/drop-overlay';
 
 type VerifyRequest = main.VerifyRequest;
 type VerifyResult = main.VerifyResult;
@@ -69,6 +72,18 @@ export function CheckPage() {
   const [progress, setProgress] = useState<ProgressEvent | null>(null);
   const [result, setResult] = useState<VerifyResult | null>(null);
   const [error, setError] = useState('');
+
+  // Drag-and-drop: .torrent → torrent field; everything else → content field.
+  const { isDragging } = useFileDrop((paths) => {
+    const dropped = paths[0];
+    if (dropped.toLowerCase().endsWith('.torrent')) {
+      setTorrentPath(dropped);
+      toast.success('Torrent file set');
+    } else {
+      setContentPath(dropped);
+      toast.success('Content path set');
+    }
+  });
 
   // Save form state to localStorage whenever values change
   useEffect(() => {
@@ -154,6 +169,7 @@ export function CheckPage() {
 
   return (
     <div className="flex flex-col h-full">
+      <DropOverlay visible={isDragging} label="Drop a .torrent or content file/folder" />
       <div className="flex-1 overflow-auto p-6 space-y-4">
         <div>
           <h1 className="text-2xl font-semibold">Check Torrent</h1>

--- a/gui/frontend/src/pages/Check.tsx
+++ b/gui/frontend/src/pages/Check.tsx
@@ -193,8 +193,9 @@ export function CheckPage() {
                   {torrentPath && (
                     <button
                       type="button"
-                      onClick={() => setTorrentPath('')}
+                      onClick={() => { setTorrentPath(''); setResult(null); setError(''); }}
                       className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                      aria-label="Clear"
                       title="Clear"
                     >
                       <X className="h-4 w-4" />
@@ -221,8 +222,9 @@ export function CheckPage() {
                   {contentPath && (
                     <button
                       type="button"
-                      onClick={() => setContentPath('')}
+                      onClick={() => { setContentPath(''); setResult(null); setError(''); }}
                       className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                      aria-label="Clear"
                       title="Clear"
                     >
                       <X className="h-4 w-4" />

--- a/gui/frontend/src/pages/Create.tsx
+++ b/gui/frontend/src/pages/Create.tsx
@@ -15,6 +15,8 @@ import { FolderOpen, File, Plus, X, Loader2, ChevronDown, Sparkles, FileSearch, 
 import { SelectPath, SelectFile, CreateTorrent, ListPresets, GetPreset, GetTrackerInfo, GetContentSize, GetRecommendedPieceSize, InspectTorrent } from '../../wailsjs/go/main/App';
 import { EventsOn } from '../../wailsjs/runtime/runtime';
 import { getEffectiveWorkers } from './Settings';
+import { useFileDrop } from '@/hooks/useFileDrop';
+import { DropOverlay } from '@/components/ui/drop-overlay';
 
 import { main, preset as presetTypes } from '../../wailsjs/go/models';
 
@@ -161,6 +163,12 @@ export function CreatePage() {
   const [contentSize, setContentSize] = useState<number>(0);
   const [recommendedPieceSize, setRecommendedPieceSize] = useState<number>(0);
   const [dialogOpen, setDialogOpen] = useState(false);
+
+  // Drag-and-drop: accept any file or folder and use it as the source path.
+  const { isDragging } = useFileDrop((paths) => {
+    setPath(paths[0]);
+    toast.success('Path set from dropped item');
+  });
 
   useEffect(() => {
     ListPresets().then(setPresets).catch((e) => toast.error('Failed to load presets: ' + String(e)));
@@ -477,6 +485,7 @@ export function CreatePage() {
 
   return (
     <div className="flex flex-col h-full">
+      <DropOverlay visible={isDragging} label="Drop a file or folder to set the source path" />
       <div className="flex-1 overflow-auto p-6 space-y-4">
         <div>
           <h1 className="text-2xl font-semibold">Create Torrent</h1>

--- a/gui/frontend/src/pages/Create.tsx
+++ b/gui/frontend/src/pages/Create.tsx
@@ -499,12 +499,24 @@ export function CreatePage() {
             <div className="space-y-1.5">
               <Label>Source Path</Label>
               <div className="flex gap-2">
-                <Input
-                  value={path}
-                  onChange={(e) => setPath(e.target.value)}
-                  placeholder="/path/to/file/or/folder"
-                  className="flex-1"
-                />
+                <div className="relative flex-1">
+                  <Input
+                    value={path}
+                    onChange={(e) => setPath(e.target.value)}
+                    placeholder="/path/to/file/or/folder"
+                    className={path ? 'pr-8' : ''}
+                  />
+                  {path && (
+                    <button
+                      type="button"
+                      onClick={() => setPath('')}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                      title="Clear"
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
+                  )}
+                </div>
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button variant="outline" size="icon" onClick={handleSelectFile}>
@@ -588,12 +600,24 @@ export function CreatePage() {
             <div className="space-y-1.5">
               <Label>Output Directory</Label>
               <div className="flex gap-2">
-                <Input
-                  value={outputDir}
-                  onChange={(e) => setOutputDir(e.target.value)}
-                  placeholder="Same as source"
-                  className="flex-1"
-                />
+                <div className="relative flex-1">
+                  <Input
+                    value={outputDir}
+                    onChange={(e) => setOutputDir(e.target.value)}
+                    placeholder="Same as source"
+                    className={outputDir ? 'pr-8' : ''}
+                  />
+                  {outputDir && (
+                    <button
+                      type="button"
+                      onClick={() => setOutputDir('')}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                      title="Clear"
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
+                  )}
+                </div>
                 <Button variant="outline" size="icon" onClick={handleSelectOutputDir}>
                   <FolderOpen className="h-4 w-4" />
                 </Button>

--- a/gui/frontend/src/pages/Create.tsx
+++ b/gui/frontend/src/pages/Create.tsx
@@ -511,8 +511,9 @@ export function CreatePage() {
                   {path && (
                     <button
                       type="button"
-                      onClick={() => setPath('')}
+                      onClick={() => { setPath(''); setResult(null); setError(''); }}
                       className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                      aria-label="Clear"
                       title="Clear"
                     >
                       <X className="h-4 w-4" />
@@ -614,6 +615,7 @@ export function CreatePage() {
                       type="button"
                       onClick={() => setOutputDir('')}
                       className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                      aria-label="Clear"
                       title="Clear"
                     >
                       <X className="h-4 w-4" />

--- a/gui/frontend/src/pages/Inspect.tsx
+++ b/gui/frontend/src/pages/Inspect.tsx
@@ -7,6 +7,8 @@ import { Input } from '@/components/ui/input';
 import { FileSearch, FolderOpen, File, Folder, Loader2, ChevronDown, ChevronRight, Lock, Globe, Copy, Check, RotateCcw, Search, X, ChevronsUpDown, Tag, User, Calendar } from 'lucide-react';
 import { SelectTorrentFile, InspectTorrent } from '../../wailsjs/go/main/App';
 import { main } from '../../wailsjs/go/models';
+import { useFileDrop } from '@/hooks/useFileDrop';
+import { DropOverlay } from '@/components/ui/drop-overlay';
 
 type InspectResult = main.InspectResult;
 type FileInfo = main.FileInfo;
@@ -352,6 +354,26 @@ export function InspectPage() {
   const [trackersOpen, setTrackersOpen] = useState(true);
   const [filesOpen, setFilesOpen] = useState(true);
 
+  // Drag-and-drop: accept .torrent files and inspect them immediately.
+  const { isDragging } = useFileDrop(async (paths) => {
+    const torrentPath = paths.find((p) => p.toLowerCase().endsWith('.torrent')) ?? paths[0];
+    if (!torrentPath.toLowerCase().endsWith('.torrent')) {
+      toast.error('Please drop a .torrent file');
+      return;
+    }
+    try {
+      setError('');
+      setIsLoading(true);
+      const info = await InspectTorrent(torrentPath);
+      setTorrentInfo(info);
+    } catch (e) {
+      setError(String(e));
+      setTorrentInfo(null);
+    } finally {
+      setIsLoading(false);
+    }
+  });
+
   // Load persisted state on mount
   useEffect(() => {
     const savedInfo = loadInspectState();
@@ -394,6 +416,7 @@ export function InspectPage() {
 
   return (
     <div className="h-full overflow-auto">
+      <DropOverlay visible={isDragging} label="Drop a .torrent file to inspect it" />
       <div className="p-6 space-y-4">
         <div className="flex items-center justify-between">
           <div>

--- a/gui/frontend/src/pages/Modify.tsx
+++ b/gui/frontend/src/pages/Modify.tsx
@@ -282,8 +282,9 @@ export function ModifyPage() {
                   {torrentPath && (
                     <button
                       type="button"
-                      onClick={() => setTorrentPath('')}
+                      onClick={() => { setTorrentPath(''); setResult(null); setError(''); }}
                       className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                      aria-label="Clear"
                       title="Clear"
                     >
                       <X className="h-4 w-4" />
@@ -397,6 +398,7 @@ export function ModifyPage() {
                       type="button"
                       onClick={() => setOutputDir('')}
                       className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                      aria-label="Clear"
                       title="Clear"
                     >
                       <X className="h-4 w-4" />

--- a/gui/frontend/src/pages/Modify.tsx
+++ b/gui/frontend/src/pages/Modify.tsx
@@ -270,13 +270,25 @@ export function ModifyPage() {
             <div className="space-y-1.5">
               <Label>Input Torrent</Label>
               <div className="flex gap-2">
-                <Input
-                  value={torrentPath}
-                  onChange={(e) => setTorrentPath(e.target.value)}
-                  placeholder="Select a .torrent file"
-                  className="flex-1"
-                />
-                <Button variant="outline" onClick={handleSelectInput}>
+                <div className="relative flex-1">
+                  <Input
+                    value={torrentPath}
+                    onChange={(e) => setTorrentPath(e.target.value)}
+                    placeholder="Select a .torrent file"
+                    className={torrentPath ? 'pr-8' : ''}
+                  />
+                  {torrentPath && (
+                    <button
+                      type="button"
+                      onClick={() => setTorrentPath('')}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                      title="Clear"
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
+                  )}
+                </div>
+                <Button variant="outline" size="icon" onClick={handleSelectInput}>
                   <FolderOpen className="h-4 w-4" />
                 </Button>
               </div>
@@ -371,12 +383,24 @@ export function ModifyPage() {
             <div className="space-y-1.5">
               <Label>Output Directory</Label>
               <div className="flex gap-2">
-                <Input
-                  value={outputDir}
-                  onChange={(e) => setOutputDir(e.target.value)}
-                  placeholder={getDirectory(torrentPath) || 'Same as input file'}
-                  className="flex-1"
-                />
+                <div className="relative flex-1">
+                  <Input
+                    value={outputDir}
+                    onChange={(e) => setOutputDir(e.target.value)}
+                    placeholder={getDirectory(torrentPath) || 'Same as input file'}
+                    className={outputDir ? 'pr-8' : ''}
+                  />
+                  {outputDir && (
+                    <button
+                      type="button"
+                      onClick={() => setOutputDir('')}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                      title="Clear"
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
+                  )}
+                </div>
                 <Button variant="outline" size="icon" onClick={handleSelectOutputDir}>
                   <FolderOpen className="h-4 w-4" />
                 </Button>

--- a/gui/frontend/src/pages/Modify.tsx
+++ b/gui/frontend/src/pages/Modify.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
@@ -9,6 +10,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Switch } from '@/components/ui/switch';
 import { FolderOpen, Plus, X, Loader2, ChevronDown, FileSearch } from 'lucide-react';
 import { SelectTorrentFile, SelectPath, ModifyTorrent, ListPresets, GetPreset, InspectTorrent } from '../../wailsjs/go/main/App';
+import { useFileDrop } from '@/hooks/useFileDrop';
+import { DropOverlay } from '@/components/ui/drop-overlay';
 
 import { main, preset as presetTypes } from '../../wailsjs/go/models';
 
@@ -83,6 +86,17 @@ export function ModifyPage() {
   const [result, setResult] = useState<ModifyResult | null>(null);
   const [error, setError] = useState('');
   const [advancedOpen, setAdvancedOpen] = useState(false);
+
+  // Drag-and-drop: accept .torrent files and populate the input field.
+  const { isDragging } = useFileDrop((paths) => {
+    const dropped = paths[0];
+    if (!dropped.toLowerCase().endsWith('.torrent')) {
+      toast.error('Please drop a .torrent file');
+      return;
+    }
+    setTorrentPath(dropped);
+    toast.success('Torrent file set');
+  });
 
   // Load presets on mount
   useEffect(() => {
@@ -240,6 +254,7 @@ export function ModifyPage() {
 
   return (
     <div className="flex flex-col h-full">
+      <DropOverlay visible={isDragging} label="Drop a .torrent file to modify it" />
       <div className="flex-1 overflow-auto p-6 space-y-4">
         <div>
           <h1 className="text-2xl font-semibold">Modify Torrent</h1>

--- a/gui/main.go
+++ b/gui/main.go
@@ -28,7 +28,11 @@ func main() {
 			Assets: assets,
 		},
 		BackgroundColour: &options.RGBA{R: 27, G: 38, B: 54, A: 1},
-		OnStartup:        app.startup,
+		DragAndDrop: &options.DragAndDrop{
+			EnableFileDrop:     true,
+			DisableWebViewDrop: true,
+		},
+		OnStartup: app.startup,
 		Bind: []interface{}{
 			app,
 		},


### PR DESCRIPTION
This PR adds three quality-of-life improvements to the GUI.

Drag and drop support (closes #128)

A full-screen overlay appears while you're dragging so it's clear the app is ready to accept the drop. You can now drag files and folders directly onto any page instead of always using the file picker buttons:

- Create — drop any file or folder to set the source path
- Inspect — drop a .torrent file to inspect it immediately
- Check — drop a .torrent file and it goes into the torrent field; drop anything else and it goes into the content path field
- Modify — drop a .torrent file to populate the input field

Window size now persists between sessions. The app restores to whatever size you left it at last time. Previously it always opened at the default size. 

Clear buttons on path inputs. A small × button appears inside any path field that has a value. Clicking it clears that field without having to manually select and delete the text. Affects the torrent, source, content, and output directory fields across Create, Check, and Modify.

<sub>Tested on Windows 11 only. The drag-and-drop feature relies on Wails' OnFileDrop API and DOM drag events, both of which may behave differently on macOS and Linux. Would appreciate testing on other platforms before merge if possible.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Window size now persists across app restarts
  * Drag-and-drop support added to Check, Create, Inspect, and Modify pages for streamlined file handling
  * Visual overlay appears during file dragging to guide users
  * Clear buttons (X) added to input fields for quick field reset
<!-- end of auto-generated comment: release notes by coderabbit.ai -->