### PR TITLE
fix(gui): harden GUI against blank-screen render crashes

### DIFF
--- a/gui/app.go
+++ b/gui/app.go
@@ -377,8 +377,10 @@ func (a *App) InspectTorrent(path string) (*InspectResult, error) {
 	// Get info using the GetInfo method
 	info := t.GetInfo()
 
-	// Collect trackers (flat list for backwards compatibility)
-	var trackerList []string
+	// Collect trackers (flat list for backwards compatibility).
+	// Initialise non-nil so an empty list marshals to [] not null, which would
+	// crash the frontend when it dereferences .length/.map (see #168).
+	trackerList := []string{}
 	if t.Announce != "" {
 		trackerList = append(trackerList, t.Announce)
 	}
@@ -390,8 +392,8 @@ func (a *App) InspectTorrent(path string) (*InspectResult, error) {
 		}
 	}
 
-	// Collect trackers by tier
-	var trackerTiers []TrackerTier
+	// Collect trackers by tier (non-nil so an empty list marshals to [] not null)
+	trackerTiers := []TrackerTier{}
 	if t.Announce != "" && len(t.AnnounceList) == 0 {
 		// Only announce URL, no announce list - single tier
 		trackerTiers = append(trackerTiers, TrackerTier{
@@ -429,6 +431,12 @@ func (a *App) InspectTorrent(path string) (*InspectResult, error) {
 	// Compute info hash
 	infoHash := t.HashInfoBytes().String()
 
+	// Normalise web seeds so an absent list marshals to [] not null
+	webSeeds := t.UrlList
+	if webSeeds == nil {
+		webSeeds = []string{}
+	}
+
 	return &InspectResult{
 		Name:         info.Name,
 		InfoHash:     infoHash,
@@ -437,7 +445,7 @@ func (a *App) InspectTorrent(path string) (*InspectResult, error) {
 		PieceCount:   info.NumPieces(),
 		Trackers:     trackerList,
 		TrackerTiers: trackerTiers,
-		WebSeeds:     t.UrlList,
+		WebSeeds:     webSeeds,
 		IsPrivate:    info.Private != nil && *info.Private,
 		Source:       info.Source,
 		Comment:      t.Comment,
@@ -485,13 +493,19 @@ func (a *App) VerifyTorrent(req VerifyRequest) (*VerifyResult, error) {
 		return nil, err
 	}
 
+	// Normalise so an empty list marshals to [] not null
+	missingFiles := result.MissingFiles
+	if missingFiles == nil {
+		missingFiles = []string{}
+	}
+
 	return &VerifyResult{
 		Completion:    result.Completion,
 		TotalPieces:   result.TotalPieces,
 		GoodPieces:    result.GoodPieces,
 		BadPieces:     result.BadPieces,
 		MissingPieces: result.MissingPieces,
-		MissingFiles:  result.MissingFiles,
+		MissingFiles:  missingFiles,
 	}, nil
 }
 

--- a/gui/frontend/src/App.tsx
+++ b/gui/frontend/src/App.tsx
@@ -6,21 +6,24 @@ import { CheckPage } from '@/pages/Check';
 import { ModifyPage } from '@/pages/Modify';
 import { SettingsPage } from '@/pages/Settings';
 import { Toaster } from '@/components/ui/sonner';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 
 function App() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route element={<Layout />}>
-          <Route path="/" element={<CreatePage />} />
-          <Route path="/inspect" element={<InspectPage />} />
-          <Route path="/check" element={<CheckPage />} />
-          <Route path="/modify" element={<ModifyPage />} />
-          <Route path="/settings" element={<SettingsPage />} />
-        </Route>
-      </Routes>
-      <Toaster />
-    </BrowserRouter>
+    <ErrorBoundary>
+      <BrowserRouter>
+        <Routes>
+          <Route element={<Layout />}>
+            <Route path="/" element={<CreatePage />} />
+            <Route path="/inspect" element={<InspectPage />} />
+            <Route path="/check" element={<CheckPage />} />
+            <Route path="/modify" element={<ModifyPage />} />
+            <Route path="/settings" element={<SettingsPage />} />
+          </Route>
+        </Routes>
+        <Toaster />
+      </BrowserRouter>
+    </ErrorBoundary>
   );
 }
 

--- a/gui/frontend/src/components/ErrorBoundary.tsx
+++ b/gui/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,89 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { AlertTriangle } from 'lucide-react';
+
+// Keys mkbrr persists in localStorage. Stale or malformed values here are the
+// most common cause of a render crash on mount, so the fallback offers to clear
+// them. Keep in sync with the STORAGE_KEY constants in the page components.
+const PERSISTED_KEYS = [
+  'mkbrr-create-form',
+  'mkbrr-create-result',
+  'mkbrr-modify-form',
+  'mkbrr-check-form',
+  'mkbrr-inspect-state',
+  'mkbrr-default-settings',
+];
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+/**
+ * Catches render-phase errors anywhere in the wrapped tree and shows a
+ * recoverable fallback instead of unmounting React into a blank window.
+ *
+ * This is a safety net for the whole class of "blank screen" bugs: a single
+ * page throwing (e.g. a backend value that marshalled to null, or stale
+ * persisted state) no longer takes down the entire app. It does not catch
+ * errors in async code or event handlers — those are surfaced via toasts.
+ */
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('Render error caught by ErrorBoundary:', error, info);
+  }
+
+  handleTryAgain = () => {
+    this.setState({ error: null });
+  };
+
+  handleResetSavedData = () => {
+    try {
+      PERSISTED_KEYS.forEach((key) => localStorage.removeItem(key));
+    } catch (e) {
+      console.error('Failed to clear saved data:', e);
+    }
+    window.location.reload();
+  };
+
+  render() {
+    const { error } = this.state;
+    if (!error) {
+      return this.props.children;
+    }
+
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-4 p-8 text-center">
+        <AlertTriangle className="h-10 w-10 text-amber-500" />
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold">Something went wrong</h2>
+          <p className="max-w-md break-words text-sm text-muted-foreground">
+            {error.message || String(error)}
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={this.handleTryAgain}
+            className="rounded-md border px-4 py-2 text-sm transition-colors hover:bg-muted"
+          >
+            Try again
+          </button>
+          <button
+            onClick={this.handleResetSavedData}
+            className="rounded-md border border-destructive/50 px-4 py-2 text-sm text-destructive transition-colors hover:bg-destructive/10"
+          >
+            Reset saved data &amp; reload
+          </button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/gui/frontend/src/components/layout/Layout.tsx
+++ b/gui/frontend/src/components/layout/Layout.tsx
@@ -1,12 +1,18 @@
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 import { AppSidebar } from './AppSidebar';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 
 export function Layout() {
+  const location = useLocation();
   return (
     <div className="flex h-screen overflow-hidden">
       <AppSidebar />
       <main className="flex-1 overflow-auto bg-background">
-        <Outlet />
+        {/* Key by route so a crash on one page clears when the user navigates
+            elsewhere (error boundaries don't reset on route change by default). */}
+        <ErrorBoundary key={location.pathname}>
+          <Outlet />
+        </ErrorBoundary>
       </main>
     </div>
   );

--- a/gui/frontend/src/pages/Create.tsx
+++ b/gui/frontend/src/pages/Create.tsx
@@ -139,7 +139,9 @@ export function CreatePage() {
 
   const [path, setPath] = useState(savedState.path ?? '');
   const [name, setName] = useState(savedState.name ?? '');
-  const [trackers, setTrackers] = useState<string[]>(savedState.trackers ?? ['']);
+  const [trackers, setTrackers] = useState<string[]>(
+    Array.isArray(savedState.trackers) && savedState.trackers.length > 0 ? savedState.trackers : ['']
+  );
   const [isPrivate, setIsPrivate] = useState(savedState.isPrivate ?? true);
   const [comment, setComment] = useState(savedState.comment ?? '');
   const [source, setSource] = useState(savedState.source ?? '');

--- a/gui/frontend/src/pages/Inspect.tsx
+++ b/gui/frontend/src/pages/Inspect.tsx
@@ -14,12 +14,52 @@ type TrackerTier = main.TrackerTier;
 
 const STORAGE_KEY = 'mkbrr-inspect-state';
 
+// Coerce a restored (possibly stale or malformed) inspect result into a shape
+// the render code can safely read. Persisted state from an older GUI version or
+// a tampered value must never crash the page on mount.
+function sanitizeInspectResult(info: unknown): InspectResult | null {
+  if (!info || typeof info !== 'object') return null;
+  const i = info as Record<string, unknown>;
+  const toStr = (v: unknown) => (typeof v === 'string' ? v : '');
+  const toNum = (v: unknown) => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
+  const toStrArr = (v: unknown) =>
+    Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : [];
+
+  const files = Array.isArray(i.files)
+    ? (i.files as unknown[])
+        .filter((f): f is Record<string, unknown> => !!f && typeof f === 'object' && typeof (f as Record<string, unknown>).path === 'string')
+        .map((f) => ({ path: f.path as string, size: toNum(f.size) }))
+    : [];
+
+  return {
+    name: toStr(i.name),
+    infoHash: toStr(i.infoHash),
+    size: toNum(i.size),
+    pieceLength: toNum(i.pieceLength),
+    pieceCount: toNum(i.pieceCount),
+    trackers: toStrArr(i.trackers),
+    trackerTiers: Array.isArray(i.trackerTiers)
+      ? (i.trackerTiers as unknown[])
+          .filter((t): t is Record<string, unknown> => !!t && typeof t === 'object')
+          .map((t) => ({ tier: toNum(t.tier), trackers: toStrArr(t.trackers) }))
+      : [],
+    webSeeds: toStrArr(i.webSeeds),
+    isPrivate: Boolean(i.isPrivate),
+    source: toStr(i.source),
+    comment: toStr(i.comment),
+    createdBy: toStr(i.createdBy),
+    creationDate: toNum(i.creationDate),
+    fileCount: toNum(i.fileCount) || files.length,
+    files,
+  } as InspectResult;
+}
+
 function loadInspectState(): InspectResult | null {
   try {
     const saved = localStorage.getItem(STORAGE_KEY);
     if (saved) {
       const parsed = JSON.parse(saved);
-      return parsed.torrentInfo || null;
+      return sanitizeInspectResult(parsed?.torrentInfo);
     }
     return null;
   } catch (e) {

--- a/gui/frontend/src/pages/Modify.tsx
+++ b/gui/frontend/src/pages/Modify.tsx
@@ -18,7 +18,7 @@ type PresetOptions = presetTypes.Options;
 
 // Get directory from path (works for both Unix and Windows paths)
 function getDirectory(path: string): string {
-  if (!path) return '';
+  if (!path || typeof path !== 'string') return '';
   // Handle both forward and backslashes
   const lastSlash = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
   return lastSlash > 0 ? path.substring(0, lastSlash) : path;
@@ -70,7 +70,9 @@ export function ModifyPage() {
   const savedState = loadFormState();
   const [torrentPath, setTorrentPath] = useState(savedState.torrentPath ?? '');
   const [outputDir, setOutputDir] = useState(savedState.outputDir ?? '');
-  const [trackers, setTrackers] = useState<string[]>(savedState.trackers ?? ['']);
+  const [trackers, setTrackers] = useState<string[]>(
+    Array.isArray(savedState.trackers) && savedState.trackers.length > 0 ? savedState.trackers : ['']
+  );
   const [setPrivate, setSetPrivate] = useState<boolean | undefined>(savedState.setPrivate);
   const [source, setSource] = useState(savedState.source ?? '');
   const [comment, setComment] = useState(savedState.comment ?? '');


### PR DESCRIPTION
The Wails GUI blanks the entire window on any uncaught React render error because there was no error boundary, and several backend methods return nil slices that marshal to JSON `null` — the class #168 began with `ListPresets`. A user hit this via Settings → New Preset (which writes an empty `presets.yaml`) → Create tab, where `presets.length` then threw and re-blanked on every launch since `/` is the Create route.

This adds a class-based `ErrorBoundary` (inside `Layout` around the route outlet, keyed by route, plus a top-level instance) so a page crash becomes a recoverable card rather than a blank screen. It also closes the nil-slice class at the source — `InspectResult.Trackers/TrackerTiers/WebSeeds` and `VerifyResult.MissingFiles` now initialise non-nil — and sanitises restored `localStorage` state in Inspect/Create/Modify. Related: #168.
