### PR TITLE
fix(schema): add missing skip_prefix and fail_on_season_warning to batch schema

### DIFF
--- a/schema/batch.json
+++ b/schema/batch.json
@@ -70,6 +70,11 @@
             "description": "Don't write creation date",
             "default": false
           },
+          "skip_prefix": {
+            "type": "boolean",
+            "description": "Don't add tracker domain prefix to output filename",
+            "default": false
+          },
           "entropy": {
             "type": "boolean",
             "description": "Randomize info hash by adding entropy field",
@@ -88,6 +93,11 @@
             "items": {
               "type": "string"
             }
+          },
+          "fail_on_season_warning": {
+            "type": "boolean",
+            "description": "Exit with error if season pack completeness check detects missing episodes",
+            "default": false
           }
         }
       }


### PR DESCRIPTION
`BatchJob` supports `skip_prefix` and `fail_on_season_warning` (both wired through `ToCreateOptions` and documented in the batch-mode docs), but `schema/batch.json` never declared them — so JSON-schema validation and editor autocomplete reject these otherwise-valid fields. This adds both as booleans defaulting to `false`.

Surfaced by a docs-vs-code audit; the docs side is fixed in s0up4200/mkbrr.com#29.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `skip_prefix` configuration option that allows users to control whether tracker domain prefixes are automatically included in the output filenames.
  * Added a new `fail_on_season_warning` configuration option that allows users to control whether the process exits with an error when season pack completeness checks detect any missing episodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->