### PR TITLE
fix(gui): allow workers 0 (auto) and up to 64 to match CLI

### DIFF
--- a/gui/frontend/src/pages/Settings.tsx
+++ b/gui/frontend/src/pages/Settings.tsx
@@ -620,7 +620,11 @@ export function SettingsPage() {
                     min={0}
                     max={64}
                     value={formData.workers}
-                    onChange={(e) => setFormData({ ...formData, workers: parseInt(e.target.value) || 0 })}
+                    onChange={(e) => {
+                      const parsed = parseInt(e.target.value);
+                      const clamped = Math.max(0, Math.min(64, Number.isNaN(parsed) ? 0 : parsed));
+                      setFormData({ ...formData, workers: clamped });
+                    }}
                     placeholder="0 = use default"
                     className="w-32"
                   />

--- a/gui/frontend/src/pages/Settings.tsx
+++ b/gui/frontend/src/pages/Settings.tsx
@@ -45,7 +45,7 @@ export interface DefaultSettings {
 }
 
 const DEFAULT_SETTINGS: DefaultSettings = {
-  workers: 1,
+  workers: 0,
 };
 
 export function loadDefaultSettings(): DefaultSettings {
@@ -72,7 +72,7 @@ export function saveDefaultSettings(settings: DefaultSettings): void {
 /**
  * Get the effective workers count, considering preset override and default settings.
  * @param presetWorkers - Workers value from a preset (0 means "use default")
- * @returns The effective number of workers to use
+ * @returns The effective number of workers to use (0 means automatic)
  */
 export function getEffectiveWorkers(presetWorkers?: number): number {
   const defaults = loadDefaultSettings();
@@ -200,7 +200,7 @@ export function SettingsPage() {
 
   // Save default settings when they change
   const handleDefaultWorkersChange = (value: number) => {
-    const newValue = Math.max(1, Math.min(32, value || 1)); // Clamp between 1-32
+    const newValue = Math.max(0, Math.min(64, Number.isNaN(value) ? 0 : value)); // Clamp between 0-64 (0 = auto)
     setDefaultWorkers(newValue);
     saveDefaultSettings({ workers: newValue });
   };
@@ -369,15 +369,16 @@ export function SettingsPage() {
               <Input
                 id="default-workers"
                 type="number"
-                min={1}
-                max={32}
+                min={0}
+                max={64}
                 value={defaultWorkers}
-                onChange={(e) => handleDefaultWorkersChange(parseInt(e.target.value) || 1)}
+                onChange={(e) => handleDefaultWorkersChange(parseInt(e.target.value))}
+                placeholder="0 = automatic"
                 className="w-32"
               />
               <p className="text-xs text-muted-foreground">
-                Number of parallel workers for hashing. Used when creating torrents without a preset,
-                or when the preset doesn't override this value.
+                Number of parallel workers for hashing. Set to 0 for automatic selection based on CPU count.
+                Used when creating torrents without a preset, or when the preset doesn't override this value.
               </p>
             </div>
           </CardContent>
@@ -460,7 +461,7 @@ export function SettingsPage() {
                               {((opts.trackers && opts.trackers.length > 0) || ((opts as any).Trackers && (opts as any).Trackers.length > 0)) && (
                                 <span>Trackers: {opts.trackers?.length || (opts as any).Trackers?.length}</span>
                               )}
-                              <span>Workers: {(opts.workers ?? (opts as any).Workers) || `default (${defaultWorkers})`}</span>
+                              <span>Workers: {(opts.workers ?? (opts as any).Workers) || `default (${defaultWorkers === 0 ? 'auto' : defaultWorkers})`}</span>
                             </div>
                           </div>
                         );
@@ -617,7 +618,7 @@ export function SettingsPage() {
                     id="preset-workers"
                     type="number"
                     min={0}
-                    max={32}
+                    max={64}
                     value={formData.workers}
                     onChange={(e) => setFormData({ ...formData, workers: parseInt(e.target.value) || 0 })}
                     placeholder="0 = use default"
@@ -625,7 +626,7 @@ export function SettingsPage() {
                   />
                   <p className="text-xs text-muted-foreground">
                     Override the default workers setting for this preset.
-                    Set to 0 to use the default ({defaultWorkers} workers).
+                    Set to 0 to use the default ({defaultWorkers === 0 ? 'auto' : `${defaultWorkers} workers`}).
                   </p>
                 </div>
               </CollapsibleContent>


### PR DESCRIPTION
Fixes #175

## Problem

The GUI's **Default Workers** setting was clamped to 1–32, while the CLI's `--workers` flag defaults to `0` (automatic, CPU-based selection) and has no upper bound. The per-preset **Workers Override** was likewise capped at 32, even though values above 32 loaded from `presets.yaml` were honored. On top of the input bounds, a falsy `parseInt(...) || 1` fallback turned an entered `0` into `1`, so auto mode was unreachable from the GUI entirely — including via presets, since the create request always carried the clamped default (≥1) that the backend used whenever a preset specified `workers: 0`.

## Changes

All in `gui/frontend/src/pages/Settings.tsx` — the Go engine already supports `0` = auto (`torrent/hasher.go`) and values above 32, so no backend changes were needed:

- Widen the **Default Workers** input to 0–64 and fix the falsy fallbacks (`Number.isNaN` check in `handleDefaultWorkersChange`) so an entered `0` survives.
- Widen the per-preset **Workers Override** max from 32 to 64.
- Change the default for new installs from `1` to `0` (auto), matching the CLI default. Previously saved settings are unaffected.
- Update helper text and preset summaries to explain `0` = automatic and render "auto" instead of "0" where the default is displayed.

With the request now able to carry `0`, auto flows end to end: Settings → `getEffectiveWorkers()` → `CreateTorrent` request → `app.go` → `hasher.hashPieces(0)` → automatic worker count.

## Verification

- `tsc && vite build` passes for the GUI frontend.
- `make test` passes (frontend-only change; existing `TestAutoWorkerCount` covers the auto path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1M6dUrY3g9nSz3QUoyskh

---
_Generated by [Claude Code](https://claude.ai/code/session_01T1M6dUrY3g9nSz3QUoyskh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automatic worker-count mode that selects a default based on CPU capacity.
  * Updated the preset UI to display `default (auto)` when automatic mode is enabled.

* **Bug Fixes**
  * Expanded worker-count input limits (default and override) to support values from `0–64`, with `0` representing automatic selection.
  * Improved value handling by clamping inputs and treating invalid entries as automatic (`0`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->