### PR TITLE
chore: bump Go to 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build app
-FROM golang:1.25-alpine3.22 AS app-builder
+FROM golang:1.26-alpine3.22 AS app-builder
 
 ARG VERSION=dev
 ARG REVISION=dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build app
-FROM golang:1.26-alpine3.22 AS app-builder
+FROM golang:1.26-alpine3.24 AS app-builder
 
 ARG VERSION=dev
 ARG REVISION=dev

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -1,5 +1,5 @@
 # build app
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine3.22 AS app-builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine3.24 AS app-builder
 RUN apk add --no-cache git tzdata
 
 ENV SERVICE=mkbrr

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -1,5 +1,5 @@
 # build app
-FROM --platform=$BUILDPLATFORM golang:1.25-alpine3.22 AS app-builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine3.22 AS app-builder
 RUN apk add --no-cache git tzdata
 
 ENV SERVICE=mkbrr

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/autobrr/mkbrr
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/anacrolix/torrent v1.61.0

--- a/gui/go.mod
+++ b/gui/go.mod
@@ -1,6 +1,6 @@
 module github.com/autobrr/mkbrr/gui
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/autobrr/mkbrr v0.0.0


### PR DESCRIPTION
Bumps the go directive to 1.26.0 in go.mod and gui/go.mod, and the Dockerfile builder image to golang:1.26-alpine3.22. CI workflows pick up the version from go.mod via go-version-file.