### PR TITLE
fix(torrent): harden update output safety

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/schollz/progressbar/v3 v3.19.1
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/sys v0.46.0
 	golang.org/x/text v0.32.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -41,7 +42,6 @@ require (
 	gitlab.com/gitlab-org/api/client-go v1.9.1 // indirect
 	golang.org/x/crypto v0.46.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
-	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/torrent/publish_file_other.go
+++ b/torrent/publish_file_other.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package torrent
+
+import "os"
+
+// publishTorrentFile installs tempPath at outputPath, optionally replacing an existing entry.
+func publishTorrentFile(tempPath, outputPath string, replace bool) error {
+	if replace {
+		return os.Rename(tempPath, outputPath)
+	}
+
+	// ponytail: atomic no-replace publication requires hard-link support; add a native primitive if unsupported filesystems become a user requirement.
+	if err := os.Link(tempPath, outputPath); err != nil {
+		return err
+	}
+	_ = os.Remove(tempPath)
+	return nil
+}

--- a/torrent/publish_file_windows.go
+++ b/torrent/publish_file_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package torrent
+
+import "golang.org/x/sys/windows"
+
+// publishTorrentFile installs tempPath at outputPath, optionally replacing an existing entry.
+func publishTorrentFile(tempPath, outputPath string, replace bool) error {
+	tempPathPointer, err := windows.UTF16PtrFromString(tempPath)
+	if err != nil {
+		return err
+	}
+	outputPathPointer, err := windows.UTF16PtrFromString(outputPath)
+	if err != nil {
+		return err
+	}
+
+	flags := uint32(windows.MOVEFILE_WRITE_THROUGH)
+	if replace {
+		flags |= windows.MOVEFILE_REPLACE_EXISTING
+	}
+	return windows.MoveFileEx(tempPathPointer, outputPathPointer, flags)
+}

--- a/torrent/update.go
+++ b/torrent/update.go
@@ -51,9 +51,11 @@ type pieceReuse struct {
 	renames      map[string]string
 	matchedFiles []int
 	reused       int
+	allowNoReuse bool
 }
 
 // UpdateTorrent structurally synchronizes an existing v1 torrent with content on disk.
+// Its default sibling output never replaces an existing filesystem entry.
 // Same-path, same-length files and explicit renames are assumed to be byte-identical;
 // callers must perform a full recreate when file bytes may change without changing size.
 func UpdateTorrent(opts UpdateOptions) (*UpdateResult, error) {
@@ -131,6 +133,7 @@ func UpdateTorrent(opts UpdateOptions) (*UpdateResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	reuse.allowNoReuse = opts.Force
 
 	generated, err := createTorrent(CreateOptions{
 		Path:             opts.ContentPath,
@@ -159,6 +162,10 @@ func UpdateTorrent(opts UpdateOptions) (*UpdateResult, error) {
 	if err := preserveMappedFileInfoKeys(oldInfoMap, newInfoMap, reuse.matchedFiles); err != nil {
 		return nil, err
 	}
+	_, newHasLength := newInfoMap["length"]
+	if !hasLength || !newHasLength || len(reuse.matchedFiles) != 1 || reuse.matchedFiles[0] < 0 {
+		delete(oldInfoMap, "md5sum")
+	}
 
 	delete(oldInfoMap, "files")
 	delete(oldInfoMap, "length")
@@ -182,10 +189,6 @@ func UpdateTorrent(opts UpdateOptions) (*UpdateResult, error) {
 		return nil, fmt.Errorf("decode updated torrent info: %w", err)
 	}
 	totalPieces := len(updatedInfo.Pieces) / 20
-	oldTotalPieces := len(oldInfo.Pieces) / 20
-	if max(oldTotalPieces, totalPieces) > 1 && reuse.reused == 0 && !opts.Force {
-		return nil, fmt.Errorf("refusing update with 0 reusable pieces (existing torrent: %d, updated torrent: %d); verify the content path or use --force", oldTotalPieces, totalPieces)
-	}
 
 	currentWriteOutputPath, err := updateOutputWritePath(outputPath)
 	if err != nil {
@@ -194,7 +197,11 @@ func UpdateTorrent(opts UpdateOptions) (*UpdateResult, error) {
 	if currentWriteOutputPath != writeOutputPath {
 		return nil, fmt.Errorf("output parent changed during update")
 	}
-	if err := writeTorrentAtomically(rootMap, writeOutputPath); err != nil {
+	torrentInfo, err := os.Stat(opts.TorrentPath)
+	if err != nil {
+		return nil, fmt.Errorf("stat input torrent: %w", err)
+	}
+	if err := writeTorrentAtomically(rootMap, writeOutputPath, torrentInfo.Mode().Perm(), !defaultOutput); err != nil {
 		return nil, err
 	}
 
@@ -253,10 +260,15 @@ func validateUpdateOutputPath(torrentPath, contentPath, outputPath string, inPla
 		if err != nil {
 			return fmt.Errorf("resolve torrent path: %w", err)
 		}
-		torrentInfo, torrentErr := os.Lstat(torrentPath)
-		outputInfo, outputErr := os.Lstat(outputPath)
-		sameExistingEntry := torrentErr == nil && outputErr == nil && os.SameFile(torrentInfo, outputInfo)
-		if outputWritePath == torrentWritePath || sameExistingEntry {
+		torrentInfo, err := os.Stat(torrentPath)
+		if err != nil {
+			return fmt.Errorf("stat torrent path: %w", err)
+		}
+		sameExistingFile, err := updateSameExistingFile(torrentInfo, outputPath)
+		if err != nil {
+			return fmt.Errorf("compare output and torrent paths: %w", err)
+		}
+		if updatePathsEqual(outputWritePath, torrentWritePath) || sameExistingFile {
 			return fmt.Errorf("output path refers to the input torrent; use in-place update instead")
 		}
 	}
@@ -265,15 +277,25 @@ func validateUpdateOutputPath(torrentPath, contentPath, outputPath string, inPla
 	if err != nil {
 		return nil
 	}
+	contentEntryPath, err := updateOutputWritePath(contentPath)
+	if err != nil {
+		return fmt.Errorf("resolve content entry: %w", err)
+	}
+	sameExistingFile, err := updateSameExistingFile(contentInfo, outputPath)
+	if err != nil {
+		return fmt.Errorf("compare output and content paths: %w", err)
+	}
+	if updatePathsEqual(outputWritePath, contentEntryPath) || sameExistingFile {
+		if contentInfo.IsDir() {
+			return fmt.Errorf("output path must not replace the content directory")
+		}
+		return fmt.Errorf("output path must not replace the content file")
+	}
 	contentResolved, err := resolvedUpdatePath(contentPath)
 	if err != nil {
 		return fmt.Errorf("resolve content path: %w", err)
 	}
 	if !contentInfo.IsDir() {
-		outputInfo, outputErr := os.Lstat(outputPath)
-		if outputWritePath == contentResolved || outputErr == nil && os.SameFile(contentInfo, outputInfo) {
-			return fmt.Errorf("output path must not replace the content file")
-		}
 		return nil
 	}
 
@@ -288,6 +310,30 @@ func validateUpdateOutputPath(torrentPath, contentPath, outputPath string, inPla
 		return fmt.Errorf("output path must not be inside the content directory")
 	}
 	return nil
+}
+
+func updatePathsEqual(left, right string) bool {
+	relative, err := filepath.Rel(left, right)
+	return err == nil && relative == "."
+}
+
+// updateSameExistingFile compares an existing non-symlink candidate without following an output symlink.
+func updateSameExistingFile(info os.FileInfo, candidatePath string) (bool, error) {
+	entryInfo, err := os.Lstat(candidatePath)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if entryInfo.Mode()&os.ModeSymlink != 0 {
+		return false, nil
+	}
+	candidateInfo, err := os.Stat(candidatePath)
+	if err != nil {
+		return false, err
+	}
+	return os.SameFile(info, candidateInfo), nil
 }
 
 func updatePathInsideDirectory(directoryPath, candidatePath string, directoryInfo os.FileInfo) (bool, error) {
@@ -526,6 +572,10 @@ func (r *pieceReuse) findReusablePieces(files []fileEntry, baseDir string, input
 	}
 
 	r.reused = len(reusable)
+	oldTotalPieces := len(r.oldPieces) / 20
+	if max(oldTotalPieces, totalPieces) > 1 && r.reused == 0 && !r.allowNoReuse {
+		return nil, fmt.Errorf("refusing update with 0 reusable pieces (existing torrent: %d, updated torrent: %d); verify the content path or use --force", oldTotalPieces, totalPieces)
+	}
 	return reusable, nil
 }
 
@@ -727,8 +777,8 @@ func normalizeTorrentPath(filePath string) string {
 	return cleaned
 }
 
-// writeTorrentAtomically writes a raw root dictionary through a same-directory temporary file.
-func writeTorrentAtomically(rootMap map[string]bencode.Bytes, outputPath string) error {
+// writeTorrentAtomically writes through a same-directory temporary file and applies the requested replacement policy.
+func writeTorrentAtomically(rootMap map[string]bencode.Bytes, outputPath string, fallbackMode os.FileMode, replace bool) error {
 	dir := filepath.Dir(outputPath)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("create output directory: %w", err)
@@ -743,8 +793,8 @@ func writeTorrentAtomically(rootMap map[string]bencode.Bytes, outputPath string)
 		_ = os.Remove(tempPath)
 	}()
 
-	mode := os.FileMode(0o644)
-	if existing, statErr := os.Stat(outputPath); statErr == nil {
+	mode := fallbackMode
+	if existing, statErr := os.Lstat(outputPath); statErr == nil && existing.Mode().IsRegular() {
 		mode = existing.Mode().Perm()
 	}
 	if err := tempFile.Chmod(mode); err != nil {
@@ -758,8 +808,11 @@ func writeTorrentAtomically(rootMap map[string]bencode.Bytes, outputPath string)
 	if err := tempFile.Close(); err != nil {
 		return fmt.Errorf("close updated torrent: %w", err)
 	}
-	if err := os.Rename(tempPath, outputPath); err != nil {
-		return fmt.Errorf("replace torrent %q: %w", outputPath, err)
+	if err := publishTorrentFile(tempPath, outputPath, replace); err != nil {
+		if replace {
+			return fmt.Errorf("replace torrent %q: %w", outputPath, err)
+		}
+		return fmt.Errorf("create torrent %q: %w", outputPath, err)
 	}
 	return nil
 }

--- a/torrent/update_test.go
+++ b/torrent/update_test.go
@@ -173,6 +173,47 @@ func TestUpdateTorrentPreservesRawInfoValues(t *testing.T) {
 	assert.Equal(t, bigInteger, files[0]["x-file-bigint"])
 }
 
+func TestUpdateTorrentKeepsOnlyValidSingleFileMD5(t *testing.T) {
+	originalPath := filepath.Join(t.TempDir(), "original.bin")
+	replacementPath := filepath.Join(t.TempDir(), "replacement.bin")
+	writeUpdateTestFile(t, originalPath, bytes.Repeat([]byte{'a'}, 131_072))
+	writeUpdateTestFile(t, replacementPath, bytes.Repeat([]byte{'b'}, 131_072))
+
+	pieceLength := uint(16)
+	original, err := CreateTorrent(CreateOptions{
+		Path:           originalPath,
+		PieceLengthExp: &pieceLength,
+		Quiet:          true,
+	})
+	require.NoError(t, err)
+	addUpdateTestInfoValue(t, original.MetaInfo, "md5sum", "keep-md5")
+	torrentPath := filepath.Join(t.TempDir(), "original.torrent")
+	writeUpdateTestTorrent(t, torrentPath, original.MetaInfo)
+
+	unchangedOutputPath := filepath.Join(t.TempDir(), "unchanged.torrent")
+	_, err = UpdateTorrent(UpdateOptions{
+		TorrentPath: torrentPath,
+		ContentPath: originalPath,
+		OutputPath:  unchangedOutputPath,
+		Quiet:       true,
+	})
+	require.NoError(t, err)
+	_, hasMD5 := readUpdateTestRawInfo(t, unchangedOutputPath)["md5sum"]
+	assert.True(t, hasMD5)
+
+	changedOutputPath := filepath.Join(t.TempDir(), "changed.torrent")
+	_, err = UpdateTorrent(UpdateOptions{
+		TorrentPath: torrentPath,
+		ContentPath: replacementPath,
+		OutputPath:  changedOutputPath,
+		Force:       true,
+		Quiet:       true,
+	})
+	require.NoError(t, err)
+	_, hasMD5 = readUpdateTestRawInfo(t, changedOutputPath)["md5sum"]
+	assert.False(t, hasMD5)
+}
+
 // TestUpdateTorrentRejectsUnsafeOutputPaths verifies output cannot replace or enter the content set.
 func TestUpdateTorrentRejectsUnsafeOutputPaths(t *testing.T) {
 	t.Run("content file identities", func(t *testing.T) {
@@ -223,6 +264,39 @@ func TestUpdateTorrentRejectsUnsafeOutputPaths(t *testing.T) {
 				assert.Equal(t, contentBytes, got)
 			})
 		}
+	})
+
+	t.Run("content symbolic link entry", func(t *testing.T) {
+		targetPath := filepath.Join(t.TempDir(), "target.bin")
+		contentPath := filepath.Join(t.TempDir(), "content-link.bin")
+		contentBytes := []byte("original content bytes")
+		writeUpdateTestFile(t, targetPath, contentBytes)
+		if err := os.Symlink(targetPath, contentPath); err != nil {
+			t.Skipf("symbolic links unavailable: %v", err)
+		}
+		pieceLength := uint(16)
+		original, err := CreateTorrent(CreateOptions{
+			Path:           contentPath,
+			PieceLengthExp: &pieceLength,
+			Quiet:          true,
+		})
+		require.NoError(t, err)
+		torrentPath := filepath.Join(t.TempDir(), "input.torrent")
+		writeUpdateTestTorrent(t, torrentPath, original.MetaInfo)
+
+		_, err = UpdateTorrent(UpdateOptions{
+			TorrentPath: torrentPath,
+			ContentPath: contentPath,
+			OutputPath:  contentPath,
+			Quiet:       true,
+		})
+		require.ErrorContains(t, err, "must not replace the content file")
+		contentInfo, err := os.Lstat(contentPath)
+		require.NoError(t, err)
+		assert.NotZero(t, contentInfo.Mode()&os.ModeSymlink)
+		got, err := os.ReadFile(targetPath)
+		require.NoError(t, err)
+		assert.Equal(t, contentBytes, got)
 	})
 
 	t.Run("inside content directory", func(t *testing.T) {
@@ -624,6 +698,43 @@ func TestUpdateTorrentDefaultsToSeparateOutput(t *testing.T) {
 	assert.Equal(t, outputBytes, afterRefusal)
 }
 
+func TestUpdateTorrentDefaultOutputDoesNotReplaceRacedFile(t *testing.T) {
+	contentPath := filepath.Join(t.TempDir(), "content.bin")
+	writeUpdateTestFile(t, contentPath, bytes.Repeat([]byte{'a'}, 131_072))
+
+	pieceLength := uint(16)
+	original, err := CreateTorrent(CreateOptions{
+		Path:           contentPath,
+		PieceLengthExp: &pieceLength,
+		Quiet:          true,
+	})
+	require.NoError(t, err)
+	torrentPath := filepath.Join(t.TempDir(), "release.torrent")
+	writeUpdateTestTorrent(t, torrentPath, original.MetaInfo)
+	outputPath := defaultUpdateOutputPath(torrentPath)
+	sentinel := []byte("do not replace")
+	created := false
+
+	_, err = UpdateTorrent(UpdateOptions{
+		TorrentPath: torrentPath,
+		ContentPath: contentPath,
+		Quiet:       true,
+		ProgressCallback: func(_, _ int, _ float64) {
+			if created {
+				return
+			}
+			created = true
+			require.NoError(t, os.WriteFile(outputPath, sentinel, 0o644))
+		},
+	})
+	require.ErrorIs(t, err, os.ErrExist)
+	require.ErrorContains(t, err, "create torrent")
+	assert.True(t, created)
+	got, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	assert.Equal(t, sentinel, got)
+}
+
 // TestUpdateTorrentRequiresForceForZeroReuse verifies a wrong content path cannot replace the input by default.
 func TestUpdateTorrentRequiresForceForZeroReuse(t *testing.T) {
 	for _, test := range []struct {
@@ -652,14 +763,19 @@ func TestUpdateTorrentRequiresForceForZeroReuse(t *testing.T) {
 			writeUpdateTestTorrent(t, torrentPath, original.MetaInfo)
 			originalBytes, err := os.ReadFile(torrentPath)
 			require.NoError(t, err)
+			hashStarted := false
 			_, err = UpdateTorrent(UpdateOptions{
 				TorrentPath: torrentPath,
 				ContentPath: unrelatedDir,
 				InPlace:     true,
 				Quiet:       true,
+				ProgressCallback: func(_, _ int, _ float64) {
+					hashStarted = true
+				},
 			})
 			wantError := fmt.Sprintf("0 reusable pieces (existing torrent: 3, updated torrent: %d)", test.updatedPieces)
 			require.ErrorContains(t, err, wantError)
+			assert.False(t, hashStarted)
 			afterRefusal, err := os.ReadFile(torrentPath)
 			require.NoError(t, err)
 			assert.Equal(t, originalBytes, afterRefusal)
@@ -843,6 +959,9 @@ func TestUpdateTorrentSingleFileSameSizeReplacementRehashes(t *testing.T) {
 	torrentPath := filepath.Join(t.TempDir(), "original.torrent")
 	outputPath := filepath.Join(t.TempDir(), "updated.torrent")
 	writeUpdateTestTorrent(t, torrentPath, original.MetaInfo)
+	if runtime.GOOS != "windows" {
+		require.NoError(t, os.Chmod(torrentPath, 0o600))
+	}
 
 	result, err := UpdateTorrent(UpdateOptions{
 		TorrentPath: torrentPath,
@@ -856,14 +975,14 @@ func TestUpdateTorrentSingleFileSameSizeReplacementRehashes(t *testing.T) {
 	assert.Equal(t, result.TotalPieces, result.HashedPieces)
 	assertUpdateMatchesFullRehash(t, outputPath, replacementPath, "original.bin", pieceLength, nil)
 
-	t.Run("sets default POSIX permissions", func(t *testing.T) {
+	t.Run("preserves input POSIX permissions", func(t *testing.T) {
 		if runtime.GOOS == "windows" {
 			t.Skip("POSIX file modes are not meaningful on Windows")
 		}
 
 		outputInfo, err := os.Stat(outputPath)
 		require.NoError(t, err)
-		assert.Equal(t, os.FileMode(0o644), outputInfo.Mode().Perm())
+		assert.Equal(t, os.FileMode(0o600), outputInfo.Mode().Perm())
 	})
 }
 

--- a/torrent/update_test.go
+++ b/torrent/update_test.go
@@ -714,6 +714,7 @@ func TestUpdateTorrentDefaultOutputDoesNotReplaceRacedFile(t *testing.T) {
 	outputPath := defaultUpdateOutputPath(torrentPath)
 	sentinel := []byte("do not replace")
 	created := false
+	var writeErr error
 
 	_, err = UpdateTorrent(UpdateOptions{
 		TorrentPath: torrentPath,
@@ -724,9 +725,10 @@ func TestUpdateTorrentDefaultOutputDoesNotReplaceRacedFile(t *testing.T) {
 				return
 			}
 			created = true
-			require.NoError(t, os.WriteFile(outputPath, sentinel, 0o644))
+			writeErr = os.WriteFile(outputPath, sentinel, 0o644)
 		},
 	})
+	require.NoError(t, writeErr)
 	require.ErrorIs(t, err, os.ErrExist)
 	require.ErrorContains(t, err, "create torrent")
 	assert.True(t, created)


### PR DESCRIPTION
## Summary

This hardens torrent updates at the filesystem, metadata, and hashing boundaries found during a full review of the branch merged by #179.

### Findings addressed

1. **New outputs discarded restrictive permissions.** The atomic writer always applied `0644` when the destination did not already exist. A private input torrent could therefore become world-readable, exposing tracker URLs or embedded passkeys. New outputs now inherit the input torrent's permissions; replacements preserve the existing regular destination's permissions.

2. **A content symlink could be replaced through `--output`.** Content validation followed the content symlink to its target, while output publication intentionally preserved the final path component. Passing the content symlink itself as the output therefore bypassed the identity check and replaced that symlink entry. Validation now compares the preserved entry paths while continuing to allow a distinct output symlink to be replaced without touching its target.

3. **Default-output collision handling had a TOCTOU overwrite race.** The default path was checked before hashing, then published with a replacing rename. A file created at that path during hashing could be silently overwritten. Publication now performs an atomic no-replace operation: `MoveFileEx` without replacement on Windows and link/unlink publication on non-Windows systems.

4. **Single-file `md5sum` metadata could become stale.** Raw info metadata was retained while structural fields and piece hashes changed, so a top-level BEP 3 checksum could continue describing old content. The update flow now retains that checksum only when the single-file content mapping remains valid and removes it for replaced or structurally changed content.

5. **Zero-reuse safety checks ran after expensive hashing.** An update that would ultimately be rejected for reusing no pieces still hashed the entire content first. Reuse is now evaluated before the hasher starts, so the operation fails immediately unless `--force` explicitly permits a full rehash.

### Provenance

All five findings were introduced by the implementation merged in #179. None were pre-existing on `main` before #179.

## Validation

- `go test ./...`
- `go test -race -short ./torrent`
- `go vet ./...`
- Linux cross-build: `GOOS=linux CGO_ENABLED=0 go build ./...`
- `golangci-lint run --new-from-rev=origin/main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer torrent output publishing across Windows and other platforms.
  * Added controlled replacement support for existing output files.
  * Preserves input file permissions by default when writing updated torrents.
  * Supports forced piece reuse behavior during updates.

* **Bug Fixes**
  * Prevents accidental replacement of protected content files, directories, and raced output files.
  * Preserves valid single-file MD5 metadata only when content remains unchanged.
  * Stops processing safely when no reusable pieces are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->