### PR TITLE
perf(torrent): cap read buffers and bound open file descriptors

### DIFF
--- a/torrent/hasher.go
+++ b/torrent/hasher.go
@@ -25,7 +25,7 @@ type pieceHasher struct {
 	reusablePieces   map[int][]byte
 
 	startTime               time.Time
-	bytesProcessed          int64
+	bytesProcessed          atomic.Int64
 	failOnSeasonPackWarning bool
 }
 
@@ -71,8 +71,9 @@ func (h *pieceHasher) optimizeForWorkload() (int, int) {
 		numWorkers = defaultWorkerCount(true)
 	}
 
-	// reads never exceed pieceLen, so a larger buffer is wasted memory per worker
-	readSize = min(readSize, int(h.pieceLen))
+	// reads never exceed pieceLen, so a larger buffer is wasted memory per worker;
+	// compare in int64: int(pieceLen) wraps on 32-bit for huge piece lengths
+	readSize = int(min(int64(readSize), h.pieceLen))
 
 	// ensure we don't create more workers than pieces to process
 	if numWorkers > h.numPieces {
@@ -123,7 +124,7 @@ func (h *pieceHasher) hashPieces(numWorkers int) error {
 	}
 
 	h.startTime = time.Now()
-	h.bytesProcessed = 0
+	h.bytesProcessed.Store(0)
 
 	h.display.ShowFiles(h.files, numWorkers)
 
@@ -173,7 +174,7 @@ func (h *pieceHasher) hashPieces(numWorkers int) error {
 				return
 			case <-ticker.C:
 				completed := atomic.LoadUint64(&completedPieces)
-				bytesProcessed := atomic.LoadInt64(&h.bytesProcessed)
+				bytesProcessed := h.bytesProcessed.Load()
 				elapsed := time.Since(h.startTime).Seconds()
 
 				var hashrate float64
@@ -312,7 +313,7 @@ func (h *pieceHasher) hashPieceRange(startPiece, endPiece int, completedPieces *
 		}
 
 		if bytesHashed > 0 {
-			atomic.AddInt64(&h.bytesProcessed, bytesHashed)
+			h.bytesProcessed.Add(bytesHashed)
 		}
 
 		h.pieces[pieceIndex] = hasher.Sum(h.pieces[pieceIndex][:0])

--- a/torrent/hasher.go
+++ b/torrent/hasher.go
@@ -40,12 +40,6 @@ func (h *pieceHasher) optimizeForWorkload() (int, int) {
 		return 0, 0
 	}
 
-	maxFileSize := int64(0)
-	for _, f := range h.files {
-		if f.length > maxFileSize {
-			maxFileSize = f.length
-		}
-	}
 	avgFileSize := h.totalSize / int64(len(h.files))
 
 	var readSize, numWorkers int
@@ -76,6 +70,9 @@ func (h *pieceHasher) optimizeForWorkload() (int, int) {
 		readSize = 8 << 20 // 8 MiB
 		numWorkers = defaultWorkerCount(true)
 	}
+
+	// reads never exceed pieceLen, so a larger buffer is wasted memory per worker
+	readSize = min(readSize, int(h.pieceLen))
 
 	// ensure we don't create more workers than pieces to process
 	if numWorkers > h.numPieces {
@@ -224,12 +221,13 @@ func (h *pieceHasher) hashPieceRange(startPiece, endPiece int, completedPieces *
 	defer h.bufferPool.Put(buf)
 
 	hasher := sha1.New()
-	readers := make([]*fileReader, len(h.files))
+	// pieces and the files within them are processed in ascending order, so a
+	// single open reader suffices: one FD per worker regardless of file count
+	var reader *fileReader
+	readerIndex := -1
 	defer func() {
-		for _, reader := range readers {
-			if reader != nil {
-				_ = reader.file.Close()
-			}
+		if reader != nil {
+			_ = reader.file.Close()
 		}
 	}()
 
@@ -263,8 +261,10 @@ func (h *pieceHasher) hashPieceRange(startPiece, endPiece int, completedPieces *
 				continue
 			}
 
-			reader := readers[fileIndex]
-			if reader == nil {
+			if readerIndex != fileIndex {
+				if reader != nil {
+					_ = reader.file.Close()
+				}
 				f, err := os.Open(file.path)
 				if err != nil {
 					return fmt.Errorf("failed to open file %s: %w", file.path, err)
@@ -272,9 +272,8 @@ func (h *pieceHasher) hashPieceRange(startPiece, endPiece int, completedPieces *
 				reader = &fileReader{
 					file:     f,
 					position: 0,
-					length:   file.length,
 				}
-				readers[fileIndex] = reader
+				readerIndex = fileIndex
 			}
 
 			if reader.position != readStart {

--- a/torrent/hasher_test.go
+++ b/torrent/hasher_test.go
@@ -489,10 +489,13 @@ func TestPieceHasher_OptimizeForWorkload_RespectsPlatformWorkerCap(t *testing.T)
 	numPieces := int((offset + (1 << 20) - 1) / (1 << 20))
 	hasher := NewPieceHasher(files, 1<<20, numPieces, &mockDisplay{}, false)
 
-	_, workers := hasher.optimizeForWorkload()
+	readSize, workers := hasher.optimizeForWorkload()
 	maxWorkers := autoWorkerCount(cpuCount, true, runtime.GOOS)
 	if workers > maxWorkers {
 		t.Fatalf("expected workers <= platform cap (%d), got %d", maxWorkers, workers)
+	}
+	if int64(readSize) > hasher.pieceLen {
+		t.Fatalf("expected readSize <= piece length (%d), got %d", hasher.pieceLen, readSize)
 	}
 }
 

--- a/torrent/hasher_test.go
+++ b/torrent/hasher_test.go
@@ -9,10 +9,12 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"sync"
 	"testing"
 
 	"github.com/autobrr/mkbrr/internal/trackers"
+	"github.com/stretchr/testify/assert"
 )
 
 // mockDisplay implements Displayer interface for testing
@@ -494,9 +496,18 @@ func TestPieceHasher_OptimizeForWorkload_RespectsPlatformWorkerCap(t *testing.T)
 	if workers > maxWorkers {
 		t.Fatalf("expected workers <= platform cap (%d), got %d", maxWorkers, workers)
 	}
-	if int64(readSize) > hasher.pieceLen {
-		t.Fatalf("expected readSize <= piece length (%d), got %d", hasher.pieceLen, readSize)
+	assert.LessOrEqual(t, int64(readSize), hasher.pieceLen)
+}
+
+func TestPieceHasher_OptimizeForWorkload_LargePieceLengthOn32Bit(t *testing.T) {
+	if strconv.IntSize != 32 {
+		t.Skip("requires a 32-bit build")
 	}
+
+	hasher := NewPieceHasher([]fileEntry{{length: 1 << 30}}, 1<<32, 1, &mockDisplay{}, false)
+
+	readSize, _ := hasher.optimizeForWorkload()
+	assert.Equal(t, 8<<20, readSize)
 }
 
 func TestPieceHasher_CorruptedData(t *testing.T) {

--- a/torrent/types.go
+++ b/torrent/types.go
@@ -68,7 +68,6 @@ type fileEntry struct {
 type fileReader struct {
 	file     *os.File
 	position int64
-	length   int64
 }
 
 // TorrentInfo contains summary information about the created torrent

--- a/torrent/verify.go
+++ b/torrent/verify.go
@@ -577,7 +577,7 @@ func (v *pieceVerifier) verifyPieceRange(startPiece, endPiece int, completedPiec
 					v.mutex.Unlock()
 					goto nextPiece // Use goto to ensure completedPieces is incremented
 				}
-				reader = &fileReader{file: f, position: -1, length: file.length}
+				reader = &fileReader{file: f, position: -1}
 				readers[fIdx] = reader
 			}
 


### PR DESCRIPTION
Read buffers were sized 4-8 MiB, but no read ever exceeds the piece length, so with 1 MiB pieces 16 workers allocated 128 MiB to use 16 MiB. Each worker also kept every file in its piece range open until the range finished, which can exhaust file descriptors on torrents with thousands of files. Workers visit files in ascending order, so one open file per worker is enough. Also removes a dead `maxFileSize` computation.

Benchmarked old and new binaries interleaved on the same machine, once at n=8 back to back and once at n=6 with 90 s idle before every run to rule out thermal drift. Hashing speed did not regress and allocated bytes dropped 75%.

| benchmark | run | time old | time new | delta | B/op old | B/op new |
|---|---|---|---|---|---|---|
| single file (256 MiB) | interleaved n=8 | 23.7 ms | 21.7 ms | -8.2% (p=0.000) | 64.0 MiB | 16.0 MiB |
| season pack (8x128 MiB) | interleaved n=8 | 77.1 ms | 73.1 ms | ~ (p=0.083) | 126.8 MiB | 31.8 MiB |
| single file (256 MiB) | cooled n=6 | 22.7 ms | 23.1 ms | ~ (p=1.000) | 64.0 MiB | 16.0 MiB |
| season pack (8x128 MiB) | cooled n=6 | 85.6 ms | 84.7 ms | ~ (p=0.589) | 126.6 MiB | 31.7 MiB |

All B/op deltas are -75% at p=0.002.

A review found that the clamp broke 32-bit builds: `int(pieceLen)` wraps negative for huge piece lengths. Fixing it surfaced a pre-existing 32-bit crash, `bytesProcessed` was not 8-byte aligned so `atomic.AddInt64` panicked. Both are fixed (clamp in int64, `atomic.Int64`) and verified with the full test suite under `GOARCH=386`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved file hashing efficiency and reduced unnecessary memory usage.
  * Optimized read-size calculations for faster piece processing.
  * Improved resource handling by reusing and closing file readers appropriately.

* **Reliability**
  * Strengthened progress tracking during hashing.
  * Added validation to ensure read sizes remain within configured piece limits.
  * Added coverage for large-piece processing on 32-bit systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->