### PR TITLE
chore: add copyright notices and SPDX headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,8 @@ Summary
 
 ## License
 
+Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the [mkbrr contributors](https://github.com/autobrr/mkbrr/graphs/contributors).
+
 This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
 
 See [LICENSE](LICENSE) for the full license text.

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package cmd
 
 import (

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package cmd
 
 import (

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package cmd
 
 import (

--- a/cmd/modify.go
+++ b/cmd/modify.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package cmd
 
 import (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,14 +1,17 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package cmd
 
 import (
 	"github.com/spf13/cobra"
 )
 
-const banner = `         __   ___.                 
-  _____ |  | _\_ |________________ 
+const banner = `         __   ___.
+  _____ |  | _\_ |________________
  /     \|  |/ /| __ \_  __ \_  __ \
 |  Y Y  \    < | \_\ \  | \/|  | \/
-|__|_|  /__|_ \|___  /__|   |__|   
+|__|_|  /__|_ \|___  /__|   |__|
       \/     \/    \/              `
 
 var rootCmd = &cobra.Command{

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package cmd
 
 import (
@@ -19,7 +22,7 @@ var updateCmd = &cobra.Command{
 func init() {
 	updateCmd.SetUsageTemplate(`Usage:
   {{.CommandPath}}
-  
+
 Flags:
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}
 `)

--- a/cmd/update_torrent.go
+++ b/cmd/update_torrent.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package cmd
 
 import (

--- a/cmd/update_torrent_test.go
+++ b/cmd/update_torrent_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package cmd
 
 import (

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package cmd
 
 import (

--- a/gui/app.go
+++ b/gui/app.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package main
 
 import (

--- a/gui/frontend/src/App.tsx
+++ b/gui/frontend/src/App.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 import { useEffect } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { Layout } from '@/components/layout/Layout';

--- a/gui/frontend/src/components/ErrorBoundary.tsx
+++ b/gui/frontend/src/components/ErrorBoundary.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 import { Component, type ErrorInfo, type ReactNode } from 'react';
 import { AlertTriangle } from 'lucide-react';
 

--- a/gui/frontend/src/components/layout/AppSidebar.tsx
+++ b/gui/frontend/src/components/layout/AppSidebar.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 import { useState, useEffect } from 'react';
 import { NavLink } from 'react-router-dom';
 import { FilePlus, FileSearch, FileCheck, FileEdit, Settings, Moon, Sun, Monitor, Palette, ExternalLink, Heart } from 'lucide-react';

--- a/gui/frontend/src/components/layout/Layout.tsx
+++ b/gui/frontend/src/components/layout/Layout.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 import { Outlet, useLocation } from 'react-router-dom';
 import { AppSidebar } from './AppSidebar';
 import { ErrorBoundary } from '@/components/ErrorBoundary';

--- a/gui/frontend/src/components/ui/drop-overlay.tsx
+++ b/gui/frontend/src/components/ui/drop-overlay.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 import { Upload } from 'lucide-react';
 
 interface DropOverlayProps {

--- a/gui/frontend/src/hooks/useFileDrop.ts
+++ b/gui/frontend/src/hooks/useFileDrop.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 import { useEffect, useRef, useState } from 'react';
 import { OnFileDrop, OnFileDropOff } from '../../wailsjs/runtime/runtime';
 

--- a/gui/frontend/src/hooks/useTheme.ts
+++ b/gui/frontend/src/hooks/useTheme.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 import { useState, useEffect, useCallback } from 'react';
 
 export type Mode = 'light' | 'dark' | 'system';

--- a/gui/frontend/src/main.tsx
+++ b/gui/frontend/src/main.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 import React from 'react'
 import {createRoot} from 'react-dom/client'
 import './styles/globals.css'

--- a/gui/frontend/src/pages/Check.tsx
+++ b/gui/frontend/src/pages/Check.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 import { useState, useEffect } from 'react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';

--- a/gui/frontend/src/pages/Create.tsx
+++ b/gui/frontend/src/pages/Create.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';

--- a/gui/frontend/src/pages/Inspect.tsx
+++ b/gui/frontend/src/pages/Inspect.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 import React, { useState, useEffect } from 'react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';

--- a/gui/frontend/src/pages/Modify.tsx
+++ b/gui/frontend/src/pages/Modify.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';

--- a/gui/frontend/src/pages/Settings.tsx
+++ b/gui/frontend/src/pages/Settings.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 import { useState, useEffect } from 'react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';

--- a/gui/frontend/vite.config.ts
+++ b/gui/frontend/vite.config.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 import path from "path"
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'

--- a/gui/main.go
+++ b/gui/main.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package main
 
 import (

--- a/internal/preset/preset.go
+++ b/internal/preset/preset.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package preset
 
 import (

--- a/internal/preset/preset_test.go
+++ b/internal/preset/preset_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package preset
 
 import (

--- a/internal/trackers/trackers.go
+++ b/internal/trackers/trackers.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package trackers
 
 import "strings"

--- a/internal/trackers/trackers_test.go
+++ b/internal/trackers/trackers_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package trackers
 
 import (

--- a/main.go
+++ b/main.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package main
 
 import (

--- a/torrent/batch.go
+++ b/torrent/batch.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package torrent
 
 import (

--- a/torrent/batch_test.go
+++ b/torrent/batch_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package torrent
 
 import (

--- a/torrent/create.go
+++ b/torrent/create.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package torrent
 
 import (

--- a/torrent/create_test.go
+++ b/torrent/create_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package torrent
 
 import (

--- a/torrent/display.go
+++ b/torrent/display.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package torrent
 
 import (

--- a/torrent/display_test.go
+++ b/torrent/display_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package torrent
 
 import (

--- a/torrent/hasher.go
+++ b/torrent/hasher.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package torrent
 
 import (

--- a/torrent/hasher_benchmark_test.go
+++ b/torrent/hasher_benchmark_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package torrent
 
 import (

--- a/torrent/hasher_large_test.go
+++ b/torrent/hasher_large_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 //go:build large_tests
 // +build large_tests
 

--- a/torrent/hasher_test.go
+++ b/torrent/hasher_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package torrent
 
 import (

--- a/torrent/ignore.go
+++ b/torrent/ignore.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package torrent
 
 import (

--- a/torrent/ignore_test.go
+++ b/torrent/ignore_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package torrent
 
 import (

--- a/torrent/modify.go
+++ b/torrent/modify.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package torrent
 
 import (

--- a/torrent/modify_test.go
+++ b/torrent/modify_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package torrent
 
 import (

--- a/torrent/normalize.go
+++ b/torrent/normalize.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package torrent
 
 import (

--- a/torrent/normalize_test.go
+++ b/torrent/normalize_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package torrent
 
 import (

--- a/torrent/progress.go
+++ b/torrent/progress.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package torrent
 
 // Displayer defines the interface for displaying progress during torrent creation

--- a/torrent/seasonfinder.go
+++ b/torrent/seasonfinder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package torrent
 
 import (

--- a/torrent/seasonfinder_test.go
+++ b/torrent/seasonfinder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package torrent
 
 import (

--- a/torrent/types.go
+++ b/torrent/types.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package torrent
 
 import (

--- a/torrent/types_test.go
+++ b/torrent/types_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package torrent
 
 import "testing"

--- a/torrent/update.go
+++ b/torrent/update.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package torrent
 
 import (

--- a/torrent/update_test.go
+++ b/torrent/update_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package torrent
 
 import (

--- a/torrent/verify.go
+++ b/torrent/verify.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package torrent
 
 import (

--- a/torrent/verify_benchmark_test.go
+++ b/torrent/verify_benchmark_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package torrent
 
 import (

--- a/torrent/verify_test.go
+++ b/torrent/verify_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package torrent
 
 import (

--- a/torrent/workers.go
+++ b/torrent/workers.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package torrent
 
 import "runtime"

--- a/torrent/workers_test.go
+++ b/torrent/workers_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026, s0up4200 <s0up4200@pm.me> and the mkbrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package torrent
 
 import "testing"


### PR DESCRIPTION
Adds copyright notices and SPDX headers. Also removes trailing spaces from CLI text.

Closes #193


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a full-screen drag-and-drop overlay that displays upload guidance while files are dragged over the application.

- **Documentation**
  - Added consistent copyright attribution and GPL-2.0-or-later licensing information throughout the project.
  - Updated the README license section with copyright details for 2025–2026.

- **Style**
  - Removed trailing whitespace from command descriptions without changing command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->